### PR TITLE
Postprocessing to improve masks

### DIFF
--- a/app/routes/segmentation.py
+++ b/app/routes/segmentation.py
@@ -17,6 +17,7 @@ from app.services.segmentation.sam2 import SAM2, set_current_image_id
 from app.services.segmentation.mockup import MockupSegmentation
 from app.services.contours import get_contours
 from app.services.quantifications import Contour
+from app.services.postprocessing import postprocess_binary_mask
 
 # Set up logging
 logger = logging.getLogger(__name__)
@@ -83,6 +84,8 @@ async def segment_image(request: SegmentationRequest, db: Session = Depends(get_
 
     masks_response = []
     for mask, quality in zip(masks, quality):
+        if request.apply_post_processing:
+            mask = postprocess_binary_mask(mask)
         contours = get_contours(mask)
         contours_response = []
         for contour in contours:

--- a/app/schemas/segmentation_and_masks.py
+++ b/app/schemas/segmentation_and_masks.py
@@ -72,6 +72,7 @@ class SegmentationRequest(BaseModel):
     """ Model for validating the segmentation request. """
     use_prompts: Annotated[bool, ("Use prompts for segmentation (=true) or use automatic segmentation "
                                   "without prompts (=false).")] = True
+    apply_post_processing: Annotated[bool, "Apply post-processing to the segmentation."] = True
     image_id: Annotated[int, "ID of the image to segment."] = 0
     model: Annotated[str, "Model to use for segmentation."] = "SAM2Tiny"
     min_x: Annotated[float, "Coordinates must be between 0 and 1."] = 0

--- a/app/services/postprocessing.py
+++ b/app/services/postprocessing.py
@@ -1,0 +1,14 @@
+import cv2 as cv
+import numpy as np
+
+
+def postprocess_binary_mask(mask: np.ndarray):
+    """Post-process a binary mask by removing small objects and filling holes."""
+    # Ensure mask is binary
+    if np.unique(mask).size > 2:
+        raise ValueError("Input mask is not binary. Postprocessing requires a binary mask.")
+
+    # Fill holes via Closing
+    mask = cv.morphologyEx(mask, cv.MORPH_CLOSE, np.ones((3, 3), np.uint8))
+
+    return mask


### PR DESCRIPTION
Added basic postprocessing to improve segmentation masks. Can be turned off via the segmentation request. Default is True. Applies Closing to the binary masks.