### PR TITLE
Scale integration and quantification geometry updates

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -15,6 +15,7 @@ from app.routes.general.labels import router as label_router
 from app.routes.general.masks import router as mask_router
 from app.routes.general.members import invite_router, router as member_router
 from app.routes.general.reviews import router as review_router
+from app.routes.general.pixel_scale import router as scale_router
 from app.routes.general.status import router as status_router
 from app.routes.services.suggestion_router import router as suggestion_segmentation_router
 from app.routes.services.label_space_router import router as label_space_router
@@ -81,6 +82,7 @@ def create_app():
     app.include_router(mask_router)
     app.include_router(contour_router)
     app.include_router(label_router)
+    app.include_router(scale_router)
 
     # Services; Add your own service here!
     app.include_router(prompted_segmentation_router)

--- a/app/exceptions.py
+++ b/app/exceptions.py
@@ -1,0 +1,27 @@
+"""Domain-specific exceptions for the IQuana backend.
+
+Routes catch only the specific exception type they handle; every other exception
+bubbles up uncaught so FastAPI returns a 500 with a full traceback in the logs.
+This prevents silent misclassification of bugs as "404 Not Found" (RULE 1).
+"""
+
+
+class IQuanaBaseError(Exception):
+    """Base class for all domain-specific errors in this project."""
+    pass
+
+
+class ImageNotFoundError(IQuanaBaseError):
+    """Raised when an image_id does not match any row in the images table."""
+    pass
+
+
+class InvalidScaleError(IQuanaBaseError):
+    """Raised when scale inputs are logically invalid (e.g. non-positive values,
+    zero-length drawn line, or missing unit)."""
+    pass
+
+
+class DatasetNotFoundError(IQuanaBaseError):
+    """Raised when a dataset_id does not match any row in the datasets table."""
+    pass

--- a/app/routes/general/datasets.py
+++ b/app/routes/general/datasets.py
@@ -28,9 +28,11 @@ from app.services.database_access.datasets import ContourSelection, export_datas
 from app.services.quantification import (
     APPEARANCE_METRIC_KEYS,
     CONTEXTUAL_METRIC_KEYS,
+    GEOMETRY_METRIC_KEYS,
     RELATIONAL_METRIC_KEYS,
     compute_appearance_metrics_for_dataset,
     compute_contextual_metrics_for_dataset,
+    compute_geometry_metrics_for_dataset,
     compute_relational_metrics_for_dataset,
 )
 from app.services.util import get_mask_path_from_image_path
@@ -64,9 +66,9 @@ def _resolve_profile_scoping(
 ) -> tuple[dict[str, list[int] | None] | None, set[str]]:
     """Resolve a profile id into (metric_scoping, tiers_to_compute).
 
-    Returns ``(None, {"appearance", "contextual", "relational"})`` when ``profile_id`` is
+    Returns ``(None, {"geometry", "appearance", "contextual", "relational"})`` when ``profile_id`` is
     None so the legacy no-profile path aggregates every metric and lazily computes all
-    non-geometry tiers, exactly as before. When a profile is given, ``metric_scoping`` maps
+    tiers, exactly as before. When a profile is given, ``metric_scoping`` maps
     each of the profile's metric keys to its label scope (last entry wins if a key repeats),
     and the tier set contains only the tiers the profile actually references, so e.g. a
     geometry-only profile never pays the appearance image-decode or relational compute cost.
@@ -86,6 +88,8 @@ def _resolve_profile_scoping(
         metric_scoping[entry.metric_key] = entry.label_ids
 
     tiers: set[str] = set()
+    if any(key in GEOMETRY_METRIC_KEYS for key in metric_scoping):
+        tiers.add("geometry")
     if any(key in APPEARANCE_METRIC_KEYS for key in metric_scoping):
         tiers.add("appearance")
     if any(key in CONTEXTUAL_METRIC_KEYS for key in metric_scoping):
@@ -557,6 +561,8 @@ async def get_dataset_quantification_summary(
     # relational compute cost entirely.
     metric_scoping, profile_tiers = _resolve_profile_scoping(db, dataset_id, profile_id)
 
+    if "geometry" in profile_tiers:
+        compute_geometry_metrics_for_dataset(db, dataset_id, only_stale=True)
     if include_appearance and "appearance" in profile_tiers:
         compute_appearance_metrics_for_dataset(db, dataset_id, only_stale=True)
     if include_contextual and "contextual" in profile_tiers:
@@ -878,6 +884,8 @@ async def download_dataset_quantification(
     # When a profile is given, the export emits one column per profile metric/component
     # from contour_metrics; otherwise it keeps the legacy four-geometry-column shape.
     metric_scoping, profile_tiers = _resolve_profile_scoping(db, dataset_id, profile_id)
+    if "geometry" in profile_tiers:
+        compute_geometry_metrics_for_dataset(db, dataset_id, only_stale=True)
     if profile_id is not None:
         if "appearance" in profile_tiers:
             compute_appearance_metrics_for_dataset(db, dataset_id, only_stale=True)

--- a/app/routes/general/pixel_scale.py
+++ b/app/routes/general/pixel_scale.py
@@ -1,129 +1,147 @@
-"""Pixel-scale endpoints.
+"""HTTP routes for reading and setting the physical pixel scale of an image.
 
-NOTE: this router is still not registered in `create_app()` — it never was, and
-wiring it up would expose endpoints the frontend does not call yet. Its
-`APIRouter("/scale")` call (a positional argument FastAPI rejects) is fixed and
-the permission dependencies are in place, so registering it later is a one-line
-change rather than a new hole. Setting the scale rewrites every quantification
-number in the dataset, hence `pixel_scale.set` rather than annotation rights.
+Each handler validates the request shape, enforces the corresponding dataset
+permission, calls the service, and maps domain exceptions to HTTP status codes.
 """
 from logging import getLogger
 
 from fastapi import APIRouter, Depends, HTTPException
-from iquana_toolbox.schemas.scale import ScaleInput
+from pydantic import BaseModel, Field
 from sqlalchemy.orm import Session
 
 from app.database import get_session
-from app.database.images import Images
+from app.exceptions import DatasetNotFoundError, ImageNotFoundError, InvalidScaleError
 from app.schemas.auth_user import AuthenticatedUser
 from app.schemas.permissions import Permission
-from app.services.permissions import require
-from app.services.scale_computation import compute_pixel_scale_from_points
+from app.services.auth import get_current_user
+from app.services.permissions import ensure_permission, ensure_permission_for, require
+from app.services.scale_computation import (
+    apply_scale_to_dataset,
+    get_image_scale,
+    set_image_scale,
+    set_scale_from_drawn_line,
+)
 
 router = APIRouter(prefix="/scale", tags=["scale"])
 logger = getLogger(__name__)
 
 
-@router.get('/get_pixel_scale/{image_id}')
+# ---------------------------------------------------------------------------
+# Request schemas
+# ---------------------------------------------------------------------------
+
+class SetScaleRequest(BaseModel):
+    """Body for the manual set-scale endpoint."""
+    image_id: int
+    scale_x: float = Field(..., gt=0, description="Physical size of one pixel along x.")
+    scale_y: float = Field(..., gt=0, description="Physical size of one pixel along y.")
+    unit: str = Field(..., min_length=1, description="Length unit, e.g. 'mm' or 'µm'.")
+
+
+class DrawnLineScaleRequest(BaseModel):
+    """Body for the drawn-line calibration endpoint."""
+    image_id: int
+    x1: float
+    y1: float
+    x2: float
+    y2: float
+    known_distance: float = Field(..., gt=0, description="Real-world distance between the two points.")
+    unit: str = Field(..., min_length=1, description="Unit of known_distance, e.g. 'mm'.")
+
+
+class DatasetScaleRequest(BaseModel):
+    """Body for the bulk dataset scale endpoint."""
+    dataset_id: int
+    scale_x: float = Field(..., gt=0)
+    scale_y: float = Field(..., gt=0)
+    unit: str = Field(..., min_length=1)
+
+
+# ---------------------------------------------------------------------------
+# Endpoints
+# ---------------------------------------------------------------------------
+
+@router.get("/get_pixel_scale/{image_id}")
 async def get_pixel_scale(
     image_id: int,
     db: Session = Depends(get_session),
-    user: AuthenticatedUser = Depends(require(Permission.IMAGE_READ, "image_id"))
+    user: AuthenticatedUser = Depends(require(Permission.IMAGE_READ, "image_id")),
 ):
+    """Return the current physical scale stored for an image."""
+    try:
+        return get_image_scale(db, image_id)
+    except ImageNotFoundError as exc:
+        raise HTTPException(status_code=404, detail=str(exc))
+    # All other exceptions bubble up → FastAPI returns 500
+
+
+@router.post("/set_pixel_scale")
+async def set_pixel_scale(
+    body: SetScaleRequest,
+    db: Session = Depends(get_session),
+    user: AuthenticatedUser = Depends(get_current_user),
+):
+    """Set the physical scale for an image and mark scale-dependent metrics stale.
+
+    Returns the stored scale values on success.
     """
-    Get the pixel scale for a given image.
+    ensure_permission_for(user, "image_id", body.image_id, Permission.PIXEL_SCALE_SET, db)
+    try:
+        result = set_image_scale(db, body.image_id, body.scale_x, body.scale_y, body.unit)
+    except ImageNotFoundError as exc:
+        raise HTTPException(status_code=404, detail=str(exc))
+    except InvalidScaleError as exc:
+        raise HTTPException(status_code=422, detail=str(exc))
+    return {"message": "Scale set successfully.", **result}
 
-    Args:
-        image_id (int): The ID of the image.
-        db (Session): The database session.
-        user (AuthenticatedUser): The current authenticated user.
 
-    Returns:
-        dict: The pixel scale information.
+@router.post("/set_pixel_scale_via_drawn_line")
+async def set_pixel_scale_via_drawn_line(
+    body: DrawnLineScaleRequest,
+    db: Session = Depends(get_session),
+    user: AuthenticatedUser = Depends(get_current_user),
+):
+    """Compute and store the physical scale from a user-drawn calibration line.
+
+    The user provides two pixel coordinates on the image and the known real-world
+    distance between them. The service computes the scale and persists it.
     """
-    # Fetch the image from the database
-    image = db.query(Images).filter_by(id=image_id).first()
-    if not image:
-        raise HTTPException(status_code=404, detail="Image not found")
- 
-    # Return the pixel scale information
-    return {
-        "scale_x": image.scale_x,
-        "scale_y": image.scale_y,
-        "unit": image.unit
-    }
+    ensure_permission_for(user, "image_id", body.image_id, Permission.PIXEL_SCALE_SET, db)
+    try:
+        result = set_scale_from_drawn_line(
+            db,
+            body.image_id,
+            (body.x1, body.y1),
+            (body.x2, body.y2),
+            body.known_distance,
+            body.unit,
+        )
+    except ImageNotFoundError as exc:
+        raise HTTPException(status_code=404, detail=str(exc))
+    except InvalidScaleError as exc:
+        raise HTTPException(status_code=422, detail=str(exc))
+    return {"message": "Scale calibrated successfully.", **result}
 
 
-@router.post('/set_pixel_scale')
-async def set_pixel_scale(scale_x: float,
-                          scale_y: float,
-                          unit: str,
-                          image_id: int,
-                          user: AuthenticatedUser = Depends(
-                              require(Permission.PIXEL_SCALE_SET, "image_id")),
-                          db: Session = Depends(get_session)):
+@router.post("/apply_to_dataset")
+async def apply_scale_to_dataset_endpoint(
+    body: DatasetScaleRequest,
+    db: Session = Depends(get_session),
+    user: AuthenticatedUser = Depends(get_current_user),
+):
+    """Apply the same physical scale to every image in a dataset.
+
+    Useful when all images in a dataset share the same acquisition settings
+    (e.g. same microscope magnification). Marks scale-dependent metrics stale
+    for every affected image.
     """
-    Set the pixel scale for an image.
-
-    Args:
-        scale_x (float): The pixel scale in the x direction.
-        scale_y (float): The pixel scale in the y direction.
-        unit (str): The unit of measurement (e.g., mm).
-        image_id (int): The ID of the image to set the scale for.
-        db (Session): The database session.
-        user (AuthenticatedUser): The current authenticated user.
-
-    Returns:
-        dict: A success message with the scale information.
-    """
-    # Fetch the image from the database
-    image = db.query(Images).filter_by(id=image_id).first()
-    if not image:
-        raise HTTPException(status_code=404, detail="Image not found")
-
-    # Ensure the unit is provided
-    if not unit:
-        raise HTTPException(status_code=400, detail="Unit must be provided (e.g., mm)")
-
-    if image.scale_x is not None or image.scale_y is not None:
-        logger.warning("Overwriting existing pixel scale values.")
-
-    # Save scale information in the database
-    image.scale_x = scale_x
-    image.scale_y = scale_y
-    image.unit = unit
-    db.commit()
-
-    # Return a success response
-    return {
-        "message": "Scale set successfully",
-        "scale_x": scale_x,
-        "scale_y": scale_y,
-        "unit": unit
-    }
-
-
-@router.post('/set_pixel_scale_via_drawn_line')
-async def set_pixel_scale_via_drawn_line(scale_input: ScaleInput,
-    user: AuthenticatedUser = Depends(require(Permission.PIXEL_SCALE_SET, "image_id")),
-    db: Session = Depends(get_session)):
-    """
-    Set the pixel scale based on a known distance between two points drawn on the image.
-
-    Args:
-        scale_input (ScaleInput): Input containing the coordinates of the two points and the known distance.
-        db (Session): The database session.
-        user (AuthenticatedUser): The current authenticated user.
-
-    Returns:
-        dict: A success message with the computed scale information.
-    """
-    # Compute the scale in both directions
-    scale_x, scale_y = compute_pixel_scale_from_points(
-        (scale_input.x1, scale_input.y1),
-        (scale_input.x2, scale_input.y2),
-        scale_input.known_distance
-    )
-
-    # Return a success response
-    return set_pixel_scale(scale_x, scale_y, scale_input.unit, scale_input.image_id, db)
+    ensure_permission(user, body.dataset_id, Permission.PIXEL_SCALE_SET)
+    try:
+        result = apply_scale_to_dataset(
+            db, body.dataset_id, body.scale_x, body.scale_y, body.unit
+        )
+    except DatasetNotFoundError as exc:
+        raise HTTPException(status_code=404, detail=str(exc))
+    except InvalidScaleError as exc:
+        raise HTTPException(status_code=422, detail=str(exc))
+    return {"message": "Scale applied to dataset.", **result}

--- a/app/services/quantification.py
+++ b/app/services/quantification.py
@@ -12,7 +12,7 @@ from typing import Iterable
 
 import numpy as np
 from PIL import Image as PILImage
-from iquana_toolbox.quantification import QuantContext, get_metric
+from iquana_toolbox.quantification import QuantContext, get_metric, geometry_math as gm
 from iquana_toolbox.schemas.database.contours import Contour
 from iquana_toolbox.schemas.database.quantification import QuantificationModel
 from sqlalchemy import Select
@@ -387,6 +387,75 @@ def _images_needing_appearance_compute(
         query = query.filter(or_(*missing_or_stale_conditions))
 
     return query.order_by(Images.id).all()
+
+
+def compute_geometry_metrics_for_dataset(
+        db: Session,
+        dataset_id: int,
+        metric_keys: Iterable[str] = GEOMETRY_METRIC_KEYS,
+        only_stale: bool = True,
+        image_ids: Iterable[int] | None = None,
+) -> int:
+    """Compute geometry metrics and synchronize legacy contour columns for a dataset.
+
+    Args:
+        db: Database session.
+        dataset_id: Dataset to compute for.
+        metric_keys: Geometry metric keys to compute.
+        only_stale: Whether to skip contours with fresh requested metric rows.
+        image_ids: Optional image subset.
+
+    Returns:
+        The number of contour-metric rows written.
+    """
+    metric_keys = tuple(metric_keys)
+    if not metric_keys:
+        return 0
+
+    rows = _images_needing_appearance_compute(db, dataset_id, metric_keys, only_stale, image_ids)
+    if not rows:
+        return 0
+
+    contours_by_image: dict[int, list[Contour]] = {}
+    image_by_id: dict[int, Images] = {}
+    contour_db_by_id: dict[int, Contours] = {}
+    for contour_db, image_db in rows:
+        image_by_id[image_db.id] = image_db
+        contour_db_by_id[contour_db.id] = contour_db
+        contours_by_image.setdefault(image_db.id, []).append(Contour.from_db(contour_db))
+
+    total_rows = 0
+    images_since_commit = 0
+    for image_id, contour_schemas in contours_by_image.items():
+        image = image_by_id[image_id]
+        total_rows += compute_and_store_metrics(db, metric_keys, contour_schemas, image)
+
+        for contour_schema in contour_schemas:
+            contour_db = contour_db_by_id[contour_schema.id]
+            context = build_quant_context(image, [contour_schema])
+            points = context.points_physical(contour_schema)
+            area, perimeter = gm.area_and_perimeter(points)
+            contour_db.area = float(area)
+            contour_db.perimeter = float(perimeter)
+            contour_db.circularity = float(gm.circularity(area, perimeter))
+            contour_db.diameter = float(gm.max_diameter(points))
+
+        images_since_commit += 1
+        if images_since_commit >= _APPEARANCE_BATCH_SIZE:
+            db.commit()
+            images_since_commit = 0
+
+    if images_since_commit > 0:
+        db.commit()
+
+    logger.info(
+        "Computed geometry metrics for dataset %s: %d images, %d rows (only_stale=%s).",
+        dataset_id,
+        len(contours_by_image),
+        total_rows,
+        only_stale,
+    )
+    return total_rows
 
 
 def compute_appearance_metrics_for_dataset(

--- a/app/services/scale_computation.py
+++ b/app/services/scale_computation.py
@@ -1,32 +1,313 @@
+"""Scale computation service for the IQuana backend.
+
+Provides pure service functions (no FastAPI objects, no HTTP handling) for
+reading and writing image scale data. Routes call these functions and map
+domain exceptions to HTTP status codes.
+
+All DB mutations live here, not in the route layer (RULE 2).
+Domain-specific exceptions are raised for expected error conditions so routes
+can catch them precisely without silently swallowing unexpected bugs (RULE 1).
+"""
+import logging
+from typing import Iterable
+
 import numpy as np
+from sqlalchemy.orm import Session
 
-def compute_pixel_scale_from_points(p1, p2, known_distance):
-    """
-    Compute the real-world scale (unit/pixel) from two points and the known real-world distance.
+from app.database.contour_metrics import ContourMetrics
+from app.database.images import Images
+from app.database.masks import Masks
+from app.database.contours import Contours
+from app.exceptions import DatasetNotFoundError, ImageNotFoundError, InvalidScaleError
 
-    This is used when a user draws a line (e.g., between two ruler ticks) on an image and specifies
-    the real-world distance between them (e.g., 10 mm). The function returns the scale to convert
-    pixel distances into physical units.
+logger = logging.getLogger(__name__)
+
+# Geometry and contextual metric keys that are scale-dependent.
+# Circularity is dimensionless (scale cancels out) and appearance metrics are
+# pixel-color based — neither group needs recomputation when scale changes.
+_SCALE_DEPENDENT_METRIC_KEYS: tuple[str, ...] = (
+    "area",
+    "perimeter",
+    "max_diameter",
+    "nn_distance",
+    "mean_knn_distance",
+)
+
+
+# ---------------------------------------------------------------------------
+# Read
+# ---------------------------------------------------------------------------
+
+def get_image_scale(db: Session, image_id: int) -> dict:
+    """Return the current scale information for an image.
 
     Args:
-        p1 (tuple): (x1, y1) coordinates of the first point in pixels.
-        p2 (tuple): (x2, y2) coordinates of the second point in pixels.
-        known_distance (float): Real-world distance between the two points (e.g., in mm).
+        db: SQLAlchemy session.
+        image_id: Primary key of the image row.
 
     Returns:
-        tuple: (scale_x, scale_y) where both are equal unit-per-pixel values (e.g., mm/pixel).
+        dict with keys ``scale_x``, ``scale_y``, ``unit``.
+
+    Raises:
+        ImageNotFoundError: If ``image_id`` does not exist.
+    """
+    image = db.query(Images).filter_by(id=image_id).first()
+    if not image:
+        raise ImageNotFoundError(f"Image {image_id} not found.")
+    return {
+        "scale_x": image.scale_x,
+        "scale_y": image.scale_y,
+        "unit": image.unit,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Write — single image
+# ---------------------------------------------------------------------------
+
+def set_image_scale(
+        db: Session,
+        image_id: int,
+        scale_x: float,
+        scale_y: float,
+        unit: str,
+) -> dict:
+    """Persist a new physical scale for an image and mark dependent metrics stale.
+
+    The function validates inputs first, then updates the image row, then marks
+    only scale-dependent metric rows as stale so they are recomputed on the next
+    batch quantification run. Scale-independent metrics (circularity, appearance)
+    are intentionally left untouched.
+
+    Args:
+        db: SQLAlchemy session (caller does NOT need to commit separately —
+            this function commits after the update).
+        image_id: Primary key of the image to update.
+        scale_x: Physical size of one pixel along the x-axis in ``unit`` units.
+            Must be positive.
+        scale_y: Physical size of one pixel along the y-axis in ``unit`` units.
+            Must be positive.
+        unit: Length unit string (e.g. ``"mm"``, ``"µm"``). Must not be empty.
+
+    Returns:
+        dict with keys ``scale_x``, ``scale_y``, ``unit``.
+
+    Raises:
+        InvalidScaleError: If scale values are non-positive or unit is empty.
+        ImageNotFoundError: If ``image_id`` does not exist.
+    """
+    if not unit or not unit.strip():
+        raise InvalidScaleError("Unit must be a non-empty string (e.g. 'mm', 'µm').")
+    if scale_x <= 0 or scale_y <= 0:
+        raise InvalidScaleError(
+            f"Scale values must be positive (got scale_x={scale_x}, scale_y={scale_y})."
+        )
+
+    image = db.query(Images).filter_by(id=image_id).first()
+    if not image:
+        raise ImageNotFoundError(f"Image {image_id} not found.")
+
+    if image.scale_x != scale_x or image.scale_y != scale_y or image.unit != unit:
+        logger.info(
+            "Updating scale for image %d: scale_x=%s→%s, scale_y=%s→%s, unit=%s→%s",
+            image_id, image.scale_x, scale_x, image.scale_y, scale_y, image.unit, unit,
+        )
+        image.scale_x = scale_x
+        image.scale_y = scale_y
+        image.unit = unit
+        _mark_scale_dependent_metrics_stale(db, image_id)
+        db.commit()
+    else:
+        logger.debug("Scale for image %d unchanged; no update performed.", image_id)
+
+    return {"scale_x": scale_x, "scale_y": scale_y, "unit": unit}
+
+
+# ---------------------------------------------------------------------------
+# Write — drawn-line calibration
+# ---------------------------------------------------------------------------
+
+def set_scale_from_drawn_line(
+        db: Session,
+        image_id: int,
+        p1: tuple[float, float],
+        p2: tuple[float, float],
+        known_distance: float,
+        unit: str,
+) -> dict:
+    """Compute the physical scale from a user-drawn calibration line and persist it.
+
+    The user draws a line between two known points on the image (e.g. two ruler
+    ticks) and provides the real-world distance between them. This function derives
+    the mm/pixel (or chosen unit/pixel) scale and delegates to :func:`set_image_scale`.
+
+    Args:
+        db: SQLAlchemy session.
+        image_id: Primary key of the image.
+        p1: (x1, y1) coordinates of the first point in *image pixels* (not
+            normalised fractions).
+        p2: (x2, y2) coordinates of the second point in *image pixels*.
+        known_distance: Real-world distance between the two points in ``unit``.
+            Must be positive.
+        unit: Length unit of ``known_distance`` (e.g. ``"mm"``).
+
+    Returns:
+        dict with keys ``scale_x``, ``scale_y``, ``unit``, ``pixel_distance``.
+
+    Raises:
+        InvalidScaleError: If ``known_distance`` ≤ 0 or the two points are identical.
+        ImageNotFoundError: If ``image_id`` does not exist.
+    """
+    if known_distance <= 0:
+        raise InvalidScaleError(
+            f"known_distance must be positive (got {known_distance})."
+        )
+
+    scale_per_pixel = compute_pixel_scale_from_points(p1, p2, known_distance)
+    result = set_image_scale(db, image_id, scale_per_pixel, scale_per_pixel, unit)
+    pixel_distance = float(np.sqrt((p2[0] - p1[0]) ** 2 + (p2[1] - p1[1]) ** 2))
+    return {**result, "pixel_distance": pixel_distance}
+
+
+# ---------------------------------------------------------------------------
+# Write — bulk apply to dataset
+# ---------------------------------------------------------------------------
+
+def apply_scale_to_dataset(
+        db: Session,
+        dataset_id: int,
+        scale_x: float,
+        scale_y: float,
+        unit: str,
+) -> dict:
+    """Apply the same physical scale to all images in a dataset.
+
+    This is the common case for datasets captured at a fixed magnification: one
+    calibration is measured once and propagated to every image. Validation is
+    performed once before any DB writes.
+
+    Args:
+        db: SQLAlchemy session.
+        dataset_id: Primary key of the dataset.
+        scale_x: Physical size of one pixel along x in ``unit`` units. Must be > 0.
+        scale_y: Physical size of one pixel along y in ``unit`` units. Must be > 0.
+        unit: Length unit string.
+
+    Returns:
+        dict with ``images_updated`` (count) and the applied scale/unit values.
+
+    Raises:
+        InvalidScaleError: If scale values are non-positive or unit is empty.
+        DatasetNotFoundError: If no images belong to the dataset (or dataset missing).
+    """
+    # Validate once before touching the DB.
+    if not unit or not unit.strip():
+        raise InvalidScaleError("Unit must be a non-empty string (e.g. 'mm', 'µm').")
+    if scale_x <= 0 or scale_y <= 0:
+        raise InvalidScaleError(
+            f"Scale values must be positive (got scale_x={scale_x}, scale_y={scale_y})."
+        )
+
+    images = db.query(Images).filter_by(dataset_id=dataset_id).all()
+    if not images:
+        raise DatasetNotFoundError(
+            f"Dataset {dataset_id} not found or contains no images."
+        )
+
+    updated = 0
+    for image in images:
+        if image.scale_x != scale_x or image.scale_y != scale_y or image.unit != unit:
+            image.scale_x = scale_x
+            image.scale_y = scale_y
+            image.unit = unit
+            _mark_scale_dependent_metrics_stale(db, image.id)
+            updated += 1
+
+    if updated:
+        db.commit()
+        logger.info(
+            "Applied scale (scale_x=%s, scale_y=%s, unit=%s) to %d/%d images in dataset %d.",
+            scale_x, scale_y, unit, updated, len(images), dataset_id,
+        )
+
+    return {
+        "images_updated": updated,
+        "images_total": len(images),
+        "scale_x": scale_x,
+        "scale_y": scale_y,
+        "unit": unit,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+def _mark_scale_dependent_metrics_stale(db: Session, image_id: int) -> int:
+    """Mark scale-dependent metric rows as stale for all contours of an image.
+
+    Only geometry and contextual metrics are updated — circularity (dimensionless)
+    and appearance metrics (pixel-color based) are unaffected by a scale change
+    and are intentionally left untouched to avoid unnecessary recomputation.
+
+    Args:
+        db: SQLAlchemy session (caller is responsible for commit).
+        image_id: Primary key of the image whose contour metrics should be invalidated.
+
+    Returns:
+        The number of rows marked stale.
+    """
+    contour_ids: list[int] = [
+        row[0]
+        for row in (
+            db.query(Contours.id)
+            .join(Masks, Masks.id == Contours.mask_id)
+            .filter(Masks.image_id == image_id)
+            .all()
+        )
+    ]
+    if not contour_ids:
+        return 0
+
+    updated = (
+        db.query(ContourMetrics)
+        .filter(
+            ContourMetrics.contour_id.in_(contour_ids),
+            ContourMetrics.metric_key.in_(_SCALE_DEPENDENT_METRIC_KEYS),
+        )
+        .update({ContourMetrics.stale: True}, synchronize_session=False)
+    )
+    logger.debug(
+        "Marked %d metric rows stale for image %d after scale change.",
+        updated, image_id,
+    )
+    return updated
+
+
+def compute_pixel_scale_from_points(
+        p1: tuple[float, float],
+        p2: tuple[float, float],
+        known_distance: float,
+) -> float:
+    """Derive the real-world scale (unit/pixel) from two points and a known distance.
+
+    Args:
+        p1: (x1, y1) coordinates of the first point in image pixels.
+        p2: (x2, y2) coordinates of the second point in image pixels.
+        known_distance: Real-world distance between the points in the caller's unit.
+
+    Returns:
+        Scale value in unit/pixel (identical for x and y — isotropic assumption).
+
+    Raises:
+        InvalidScaleError: If the two points are identical (zero pixel distance).
     """
     x1, y1 = p1
     x2, y2 = p2
-
-    # Calculate pixel distance using Euclidean formula
-    pixel_distance = np.sqrt((x2 - x1)**2 + (y2 - y1)**2)
-
+    pixel_distance = float(np.sqrt((x2 - x1) ** 2 + (y2 - y1) ** 2))
     if pixel_distance == 0:
-        raise ValueError("Cannot compute scale from two identical points.")
-
-    # Scale = real-world distance (mm or other unit) / pixel distance
-    scale_per_pixel = known_distance / pixel_distance
-
-    # Return the same scale in both X and Y directions
-    return scale_per_pixel, scale_per_pixel
+        raise InvalidScaleError(
+            "Cannot compute scale from two identical points. "
+            "Choose two distinct points on the image."
+        )
+    return known_distance / pixel_distance

--- a/tests/test_contour_metrics.py
+++ b/tests/test_contour_metrics.py
@@ -210,3 +210,19 @@ def test_dual_write_and_aggregation_and_backfill(session):
     repaired_area_row = session.query(ContourMetrics).filter_by(contour_id=parent1.id, metric_key="area").one()
     assert repaired_area_row.value == pytest.approx(ref.area)
     assert repaired_area_row.unit == "mm²"
+
+    from app.services.quantification import compute_geometry_metrics_for_dataset
+
+    session.query(ContourMetrics).filter(
+        ContourMetrics.metric_key.in_(["area", "perimeter", "circularity", "max_diameter"])
+    ).update({"stale": True})
+    session.commit()
+
+    rows_written = compute_geometry_metrics_for_dataset(session, ds.id, only_stale=True)
+    assert rows_written > 0
+
+    stale_count = session.query(ContourMetrics).filter(
+        ContourMetrics.metric_key.in_(["area", "perimeter", "circularity", "max_diameter"]),
+        ContourMetrics.stale.is_(True),
+    ).count()
+    assert stale_count == 0

--- a/tests/test_scale_computation.py
+++ b/tests/test_scale_computation.py
@@ -1,0 +1,147 @@
+"""Tests for app/services/scale_computation.py.
+
+Covers the main service functions: get_image_scale, set_image_scale,
+set_scale_from_drawn_line, compute_pixel_scale_from_points, and the stale-metric
+marking behaviour after a scale change.
+"""
+import math
+import pytest
+from unittest.mock import MagicMock, patch, call
+
+from app.exceptions import ImageNotFoundError, InvalidScaleError
+from app.services.scale_computation import (
+    compute_pixel_scale_from_points,
+    get_image_scale,
+    set_image_scale,
+    set_scale_from_drawn_line,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_image(scale_x=1.0, scale_y=1.0, unit="px"):
+    """Return a mock Images ORM row."""
+    img = MagicMock()
+    img.id = 42
+    img.scale_x = scale_x
+    img.scale_y = scale_y
+    img.unit = unit
+    return img
+
+
+def _make_db(image=None):
+    """Return a mock SQLAlchemy Session with query().filter_by().first() set up."""
+    db = MagicMock()
+    db.query.return_value.filter_by.return_value.first.return_value = image
+    return db
+
+
+# ---------------------------------------------------------------------------
+# compute_pixel_scale_from_points
+# ---------------------------------------------------------------------------
+
+class TestComputePixelScaleFromPoints:
+    def test_horizontal_line(self):
+        scale = compute_pixel_scale_from_points((0, 0), (100, 0), 10.0)
+        assert math.isclose(scale, 0.1, rel_tol=1e-9)
+
+    def test_diagonal_line(self):
+        # 3-4-5 right triangle: pixel_distance = 5
+        scale = compute_pixel_scale_from_points((0, 0), (3, 4), 5.0)
+        assert math.isclose(scale, 1.0, rel_tol=1e-9)
+
+    def test_identical_points_raises(self):
+        with pytest.raises(InvalidScaleError, match="identical points"):
+            compute_pixel_scale_from_points((5, 5), (5, 5), 10.0)
+
+
+# ---------------------------------------------------------------------------
+# get_image_scale
+# ---------------------------------------------------------------------------
+
+class TestGetImageScale:
+    def test_returns_scale_dict(self):
+        db = _make_db(_make_image(scale_x=0.5, scale_y=0.5, unit="mm"))
+        result = get_image_scale(db, 42)
+        assert result == {"scale_x": 0.5, "scale_y": 0.5, "unit": "mm"}
+
+    def test_raises_if_not_found(self):
+        db = _make_db(image=None)
+        with pytest.raises(ImageNotFoundError):
+            get_image_scale(db, 999)
+
+
+# ---------------------------------------------------------------------------
+# set_image_scale
+# ---------------------------------------------------------------------------
+
+class TestSetImageScale:
+    def test_updates_image_and_commits(self):
+        img = _make_image(scale_x=1.0, scale_y=1.0, unit="px")
+        db = _make_db(img)
+
+        with patch("app.services.scale_computation._mark_scale_dependent_metrics_stale") as mock_stale:
+            result = set_image_scale(db, 42, 0.25, 0.25, "mm")
+
+        assert img.scale_x == 0.25
+        assert img.scale_y == 0.25
+        assert img.unit == "mm"
+        db.commit.assert_called_once()
+        mock_stale.assert_called_once_with(db, 42)
+        assert result == {"scale_x": 0.25, "scale_y": 0.25, "unit": "mm"}
+
+    def test_no_commit_if_unchanged(self):
+        img = _make_image(scale_x=0.25, scale_y=0.25, unit="mm")
+        db = _make_db(img)
+        with patch("app.services.scale_computation._mark_scale_dependent_metrics_stale") as mock_stale:
+            set_image_scale(db, 42, 0.25, 0.25, "mm")
+        db.commit.assert_not_called()
+        mock_stale.assert_not_called()
+
+    def test_raises_on_zero_scale(self):
+        db = _make_db(_make_image())
+        with pytest.raises(InvalidScaleError, match="positive"):
+            set_image_scale(db, 42, 0.0, 1.0, "mm")
+
+    def test_raises_on_negative_scale(self):
+        db = _make_db(_make_image())
+        with pytest.raises(InvalidScaleError, match="positive"):
+            set_image_scale(db, 42, -1.0, 1.0, "mm")
+
+    def test_raises_on_empty_unit(self):
+        db = _make_db(_make_image())
+        with pytest.raises(InvalidScaleError, match="non-empty"):
+            set_image_scale(db, 42, 1.0, 1.0, "")
+
+    def test_raises_if_image_not_found(self):
+        db = _make_db(image=None)
+        with pytest.raises(ImageNotFoundError):
+            set_image_scale(db, 999, 1.0, 1.0, "mm")
+
+
+# ---------------------------------------------------------------------------
+# set_scale_from_drawn_line
+# ---------------------------------------------------------------------------
+
+class TestSetScaleFromDrawnLine:
+    def test_correct_scale_computed(self):
+        img = _make_image()
+        db = _make_db(img)
+        with patch("app.services.scale_computation._mark_scale_dependent_metrics_stale"):
+            result = set_scale_from_drawn_line(db, 42, (0, 0), (100, 0), 10.0, "mm")
+        # 10 mm / 100 px = 0.1 mm/px
+        assert math.isclose(result["scale_x"], 0.1, rel_tol=1e-9)
+        assert math.isclose(result["pixel_distance"], 100.0, rel_tol=1e-9)
+        assert result["unit"] == "mm"
+
+    def test_raises_on_zero_known_distance(self):
+        db = _make_db(_make_image())
+        with pytest.raises(InvalidScaleError, match="positive"):
+            set_scale_from_drawn_line(db, 42, (0, 0), (100, 0), 0.0, "mm")
+
+    def test_raises_on_identical_points(self):
+        db = _make_db(_make_image())
+        with pytest.raises(InvalidScaleError, match="identical"):
+            set_scale_from_drawn_line(db, 42, (5, 5), (5, 5), 10.0, "mm")


### PR DESCRIPTION
- Adds backend scale service with endpoints to get, set, and calibrate pixel scale from a drawn line, and to apply scale across a dataset.
- Persists scale changes and marks scale-dependent contour metrics stale.
- Recomputes geometry metrics on demand so quantification summaries and exports reflect the physical unit.
- Integrates with the new role-based permission model: read requires `image.read`, writes require `pixel_scale.set`.

I merged the most recent `dev` commit and ran the tool. Everything seems to work.