### PR TITLE
Feature/reviews

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -7,6 +7,7 @@ from fastapi.middleware.cors import CORSMiddleware
 
 from app.database import init_db
 from app.routes.general.admin import router as admin_router
+from app.routes.general.annotation_queue import router as annotation_queue_router
 from app.routes.general.auth import router as auth_router
 from app.routes.general.contours import router as contour_router
 from app.routes.general.datasets import router as dataset_router
@@ -76,6 +77,7 @@ def create_app():
     app.include_router(member_router)
     app.include_router(invite_router)
     app.include_router(review_router)
+    app.include_router(annotation_queue_router)
     app.include_router(image_router)
     app.include_router(image_annotation_session_router)
     app.include_router(mask_router)

--- a/app/database/__init__.py
+++ b/app/database/__init__.py
@@ -4,7 +4,7 @@ from contextlib import contextmanager
 
 import sqlite3
 
-from sqlalchemy import create_engine, event
+from sqlalchemy import create_engine, event, inspect, text
 from sqlalchemy.engine import Engine
 from sqlalchemy.orm import declarative_base, sessionmaker
 
@@ -54,6 +54,7 @@ def _import_models():
     mapper and the table missing from a fresh database.
     """
     from app.database import (  # noqa: F401  (imported for their side effects)
+        annotation_queues,
         contour_metrics,
         contours,
         dataset_members,
@@ -68,10 +69,41 @@ def _import_models():
     )
 
 
+#: Columns added to existing tables after their first release, as
+#: (table, column, DDL type). ``create_all`` creates missing *tables* but never
+#: ALTERs an existing one, so a nullable column added to a shipped model has to be
+#: patched in here for databases that predate it. Each entry is idempotent — it is
+#: only applied when the column is absent.
+_ADDED_COLUMNS = [
+    ("annotation_rejections", "resolution", "VARCHAR(16)"),
+]
+
+
+def _ensure_columns():
+    """Add late-arriving nullable columns to already-created tables.
+
+    Mirrors ``scripts/migrate_roles.py`` but runs on every boot so a dev database
+    stays in step with the models without a manual migration step. Safe on a fresh
+    database: ``create_all`` has already made the columns, so every check is a hit.
+    """
+    inspector = inspect(engine)
+    existing_tables = set(inspector.get_table_names())
+    with engine.begin() as connection:
+        for table, column, ddl in _ADDED_COLUMNS:
+            if table not in existing_tables:
+                continue
+            columns = {col["name"] for col in inspector.get_columns(table)}
+            if column in columns:
+                continue
+            logger.info("Adding missing column %s.%s", table, column)
+            connection.execute(text(f"ALTER TABLE {table} ADD COLUMN {column} {ddl}"))
+
+
 def init_db():
     logger.debug("\tInitializing database")
     _import_models()
     database.metadata.create_all(bind=engine)
+    _ensure_columns()
 
 
 def get_session():

--- a/app/database/annotation_queues.py
+++ b/app/database/annotation_queues.py
@@ -1,0 +1,52 @@
+"""Saved annotation queues: the order one annotator works a dataset's images in.
+
+Unlike the review queue (a throwaway snapshot built per session, see
+``app.services.review_queue``), an annotation queue is *persisted* per
+(dataset, user): the annotator builds it once — as-uploaded, randomized, or a
+future active-learning ordering — and re-clicking the Annotation card resumes the
+same order instead of asking again. One row per (dataset, user); rebuilding
+overwrites it.
+
+The stored ``image_order`` is the frozen list of image ids in queue order. Storing
+the resolved list (rather than only the strategy) keeps a randomized or
+active-learning order stable across sessions, and makes "as uploaded" and a
+future model-scored order look identical to the consumer that applies it.
+"""
+from datetime import datetime, timezone
+
+from sqlalchemy import (
+    Column,
+    DateTime,
+    ForeignKey,
+    Integer,
+    JSON,
+    String,
+    UniqueConstraint,
+)
+
+from app.database import database
+
+
+def _utcnow() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+class AnnotationQueues(database):
+    """One annotator's saved image ordering for a dataset."""
+
+    __tablename__ = "annotation_queues"
+    __table_args__ = (
+        UniqueConstraint("dataset_id", "username", name="uq_annotation_queue_dataset_user"),
+    )
+
+    id = Column(Integer, primary_key=True, autoincrement=True)
+    dataset_id = Column(
+        Integer, ForeignKey("datasets.id", ondelete="CASCADE"), nullable=False, index=True
+    )
+    username = Column(String, ForeignKey("users.username", ondelete="CASCADE"), nullable=False)
+    # Key of the strategy the order was built with (see app.services.annotation_queue).
+    strategy = Column(String(32), nullable=False)
+    # Frozen list of image ids in queue order — a JSON array.
+    image_order = Column(JSON, nullable=False, default=list)
+    created_at = Column(DateTime, nullable=False, default=_utcnow)
+    updated_at = Column(DateTime, nullable=False, default=_utcnow, onupdate=_utcnow)

--- a/app/database/contours.py
+++ b/app/database/contours.py
@@ -198,14 +198,15 @@ def dual_write_geometry_metrics(session, mask_id: int, contours: list["Contours"
 
 
 def _save_contour_subtree(session, contour_schema: Contour, mask_id: int, parent_id,
-                          author_username: str | None, created: list["Contours"]):
+                          author_username: str | None, created: list["Contours"],
+                          _image=None):
     """Recursive half of :func:`save_contour_tree`; appends every saved row to ``created``."""
     from app.database.users import Users  # local import to avoid circular deps
 
     # 0. Resolve the mask's image once (the recursion below reuses it) and make sure
     #    the quantification is computed from pixel-space coordinates.
     if _image is None:
-        _image = _get_image_of_mask(session, mask_id)
+        _image = _image_for_mask(session, mask_id)
     if contour_schema.quantification is None or contour_schema.quantification.is_empty:
         if _image is not None:
             contour_schema.compute_quantification(
@@ -241,7 +242,7 @@ def _save_contour_subtree(session, contour_schema: Contour, mask_id: int, parent
     # 4. Recurse for children
     for child_schema in contour_schema.children:
         _save_contour_subtree(session, child_schema, mask_id, db_contour.id,
-                              author_username, created)
+                              author_username, created, _image=_image)
 
     return db_contour
 

--- a/app/database/rejections.py
+++ b/app/database/rejections.py
@@ -36,6 +36,10 @@ class AnnotationRejections(database):
     created_at = Column(DateTime, nullable=False, default=_utcnow)
     resolved_at = Column(DateTime, nullable=True)
     resolved_by = Column(String, ForeignKey("users.username", ondelete="SET NULL"), nullable=True)
+    # How the rejection was closed, once resolved: "fixed" (the annotator reworked
+    # the annotation) or "wont_fix" (looked at, left as is). NULL while still open
+    # and on legacy rows resolved before resolution kinds existed.
+    resolution = Column(String(16), nullable=True)
 
     mask = relationship("Masks", back_populates="rejections")
 

--- a/app/routes/general/annotation_queue.py
+++ b/app/routes/general/annotation_queue.py
@@ -1,0 +1,70 @@
+"""Annotation-queue endpoints: the persisted order an annotator works images in.
+
+Unlike the review queue (a per-session snapshot), an annotation queue is saved per
+(dataset, user): the builder on the Annotation card writes it, and re-entering the
+editor resumes it. See ``app.services.annotation_queue`` for the ordering registry
+(where active-learning orderings plug in).
+"""
+from logging import getLogger
+
+from fastapi import APIRouter, Depends
+from sqlalchemy.orm import Session
+
+from app.database import get_session
+from app.schemas.annotation_queue import AnnotationQueueRequest
+from app.schemas.auth_user import AuthenticatedUser
+from app.schemas.permissions import Permission
+from app.services import annotation_queue
+from app.services.permissions import require
+
+router = APIRouter(prefix="/annotation-queue", tags=["annotation-queue"])
+logger = getLogger(__name__)
+
+
+@router.get("/datasets/{dataset_id}/summary")
+async def get_annotation_queue_summary(
+        dataset_id: int,
+        db: Session = Depends(get_session),
+        user: AuthenticatedUser = Depends(require(Permission.ANNOTATION_CREATE, "dataset_id")),
+):
+    """Counts behind the Annotation card's subcaption, the available orderings, and
+    whether the caller already has a saved queue to resume."""
+    summary = annotation_queue.summarize(dataset_id, user.username, db)
+    return {
+        "success": True,
+        "message": f"Annotation queue summary for dataset {dataset_id}.",
+        "summary": summary.model_dump(mode="json"),
+    }
+
+
+@router.get("/datasets/{dataset_id}")
+async def get_annotation_queue(
+        dataset_id: int,
+        db: Session = Depends(get_session),
+        user: AuthenticatedUser = Depends(require(Permission.ANNOTATION_CREATE, "dataset_id")),
+):
+    """The caller's saved queue for the dataset, or ``queue: null`` if none exists."""
+    queue = annotation_queue.get_saved_queue(dataset_id, user.username, db)
+    return {
+        "success": True,
+        "message": "Retrieved saved annotation queue."
+                   if queue else "No saved annotation queue.",
+        "queue": queue.model_dump(mode="json") if queue else None,
+    }
+
+
+@router.post("/datasets/{dataset_id}")
+async def build_annotation_queue(
+        dataset_id: int,
+        body: AnnotationQueueRequest,
+        db: Session = Depends(get_session),
+        user: AuthenticatedUser = Depends(require(Permission.ANNOTATION_CREATE, "dataset_id")),
+):
+    """Build the image order for the chosen strategy and save it (overwriting any
+    earlier queue for this dataset+user)."""
+    queue = annotation_queue.build_and_save_queue(dataset_id, user.username, body.strategy, db)
+    return {
+        "success": True,
+        "message": f"Built an annotation queue of {queue.total} images.",
+        "queue": queue.model_dump(mode="json"),
+    }

--- a/app/routes/general/images.py
+++ b/app/routes/general/images.py
@@ -69,6 +69,33 @@ async def upload_images(
     }
 
 
+@router.post("/backfill_dimensions")
+async def backfill_image_dimensions(
+        dataset_id: int,
+        db: Session = Depends(get_session),
+        user: AuthenticatedUser = Depends(require(Permission.DATASET_UPDATE)),
+):
+    """Repair image dimensions recorded by the old thumbnail-mutation ingest bug.
+
+    Rows uploaded before the fix stored the 200px preview's dimensions instead of
+    the native ones, which shrank the precomputed contour paths (annotations
+    huddled in the image's top-left corner), the COCO export and the pixel-space
+    geometry metrics by the same factor. This re-reads every image file of the
+    dataset, fixes mismatched dimensions and recomputes the geometry metrics of
+    the affected contours. Safe to re-run: images whose stored dimensions already
+    match are untouched.
+    """
+    result = await images_db.backfill_image_dimensions(db, dataset_id=dataset_id)
+    return {
+        "success": True,
+        "message": f"Corrected {len(result['corrected'])} images, "
+                   f"recomputed metrics for {result['recomputed_contours']} contours"
+                   + (f"; {len(result['missing'])} files missing on disk."
+                      if result["missing"] else "."),
+        **result,
+    }
+
+
 @router.delete("/{image_id}")
 async def delete_image(
         image_id: int,

--- a/app/routes/general/reviews.py
+++ b/app/routes/general/reviews.py
@@ -10,11 +10,20 @@ from fastapi import APIRouter, Depends, HTTPException, status
 from sqlalchemy.orm import Session
 
 from app.database import get_session
+from app.database.contours import Contours
 from app.database.rejections import AnnotationRejections
+from app.database.users import Users
 from app.schemas.auth_user import AuthenticatedUser
 from app.schemas.permissions import Permission
-from app.schemas.review import RejectionCreate
+from app.schemas.review import (
+    CorrectionQueueRequest,
+    RejectionCreate,
+    RejectionResolve,
+    ReviewQueueRequest,
+)
+from app.services import correction_queue, review_queue
 from app.services.auth import get_current_user
+from app.services.database_access import contours as contours_db
 from app.services.database_access import rejections as rejections_db
 from app.services.permissions import ensure_permission_for, require
 
@@ -28,6 +37,126 @@ async def get_rejection_reasons(user: AuthenticatedUser = Depends(get_current_us
     return {
         "success": True,
         "reasons": [option.model_dump(mode="json") for option in rejections_db.reason_options()],
+    }
+
+
+@router.get("/datasets/{dataset_id}/summary")
+async def get_review_summary(
+        dataset_id: int,
+        db: Session = Depends(get_session),
+        user: AuthenticatedUser = Depends(require(Permission.REVIEW_APPROVE, "dataset_id")),
+):
+    """How much review work the dataset holds, plus the available queue orderings.
+
+    Backs the "There are x instances to review" line on the management card and
+    the strategy dropdown on the review setup page.
+    """
+    summary = review_queue.summarize(dataset_id, db)
+    return {
+        "success": True,
+        "message": f"Review summary for dataset {dataset_id}.",
+        "summary": summary.model_dump(mode="json"),
+    }
+
+
+@router.post("/datasets/{dataset_id}/queue")
+async def build_review_queue(
+        dataset_id: int,
+        body: ReviewQueueRequest,
+        db: Session = Depends(get_session),
+        user: AuthenticatedUser = Depends(require(Permission.REVIEW_APPROVE, "dataset_id")),
+):
+    """Build the ordered work list for one review session.
+
+    The queue is a snapshot, not a reservation: nothing is locked, and an item
+    someone else handles mid-session simply no-ops when acted on. See
+    `app.services.review_queue` for the granularities and the sort-strategy
+    registry (where active-learning orderings plug in).
+    """
+    queue = review_queue.build_queue(dataset_id, body, db)
+    return {
+        "success": True,
+        "message": f"Built a review queue of {queue.total} items.",
+        "queue": queue.model_dump(mode="json"),
+    }
+
+
+@router.get("/datasets/{dataset_id}/correction-summary")
+async def get_correction_summary(
+        dataset_id: int,
+        db: Session = Depends(get_session),
+        user: AuthenticatedUser = Depends(require(Permission.ANNOTATION_EDIT_OWN, "dataset_id")),
+):
+    """How much correction work the dataset holds — the count behind the "x
+    instances sent back for correction" line on the management card."""
+    summary = correction_queue.summarize(dataset_id, db)
+    return {
+        "success": True,
+        "message": f"Correction summary for dataset {dataset_id}.",
+        "summary": summary.model_dump(mode="json"),
+    }
+
+
+@router.post("/datasets/{dataset_id}/correction-queue")
+async def build_correction_queue(
+        dataset_id: int,
+        body: CorrectionQueueRequest,
+        db: Session = Depends(get_session),
+        user: AuthenticatedUser = Depends(require(Permission.ANNOTATION_EDIT_OWN, "dataset_id")),
+):
+    """Build the ordered work list for one correction session.
+
+    Every open rejection in the dataset qualifies. The queue is a snapshot, not a
+    reservation: an item someone else resolves mid-session simply no-ops when acted
+    on. See `app.services.correction_queue` for ordering and grouping.
+    """
+    queue = correction_queue.build_queue(dataset_id, body, db)
+    return {
+        "success": True,
+        "message": f"Built a correction queue of {queue.total} items.",
+        "queue": queue.model_dump(mode="json"),
+    }
+
+
+@router.post("/masks/{mask_id}/approve")
+async def approve_mask(
+        mask_id: int,
+        include_reviewed: bool = False,
+        db: Session = Depends(get_session),
+        user: AuthenticatedUser = Depends(require(Permission.REVIEW_APPROVE, "mask_id")),
+):
+    """Approve every not-yet-reviewed contour of a mask at once.
+
+    This is the image-level "Accept" of the review queue. With `include_reviewed`
+    the caller's approval is also added to contours other reviewers already signed
+    off on (matching a queue built with the same flag) — approvals are additive,
+    never replaced. Separation of duties still applies per contour: the caller's
+    own annotations are skipped rather than self-approved, and reported back in
+    `skipped`.
+    """
+    untouched_by_caller = (
+        ~Contours.reviewed_by.any(Users.username == user.username)
+        if include_reviewed else ~Contours.reviewed_by.any()
+    )
+    pending = (
+        db.query(Contours.id)
+        .filter(Contours.mask_id == mask_id,
+                Contours.temporary.is_(False),
+                untouched_by_caller)
+        .all()
+    )
+    approved, skipped = [], []
+    for (contour_id,) in pending:
+        if await contours_db.review_contour(contour_id, user, db, strict=False):
+            approved.append(contour_id)
+        else:
+            skipped.append(contour_id)
+    return {
+        "success": True,
+        "message": f"Approved {len(approved)} contours on mask {mask_id}"
+                   + (f", skipped {len(skipped)} of your own." if skipped else "."),
+        "approved": approved,
+        "skipped": skipped,
     }
 
 
@@ -76,6 +205,7 @@ async def list_mask_rejections(
 @router.patch("/rejections/{rejection_id}/resolve")
 async def resolve_rejection(
         rejection_id: int,
+        body: RejectionResolve | None = None,
         db: Session = Depends(get_session),
         user: AuthenticatedUser = Depends(get_current_user),
 ):
@@ -83,13 +213,20 @@ async def resolve_rejection(
 
     Resolving needs `annotation.edit_own` on the dataset — the annotator fixing
     the problem is the one who closes it, not only the reviewer who raised it.
+    Resolving deliberately does not require an edit: "I looked, the annotation is
+    correct as it is" is a legitimate resolution. The optional body's `resolution`
+    records how it was closed — the correction queue sends `fixed` for "Mark as
+    done" and `wont_fix` for "Won't fix".
     """
     rejection = db.query(AnnotationRejections).filter_by(id=rejection_id).first()
     if rejection is None:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Rejection not found.")
     ensure_permission_for(user, "mask_id", rejection.mask_id, Permission.ANNOTATION_EDIT_OWN, db)
 
-    resolved = await rejections_db.resolve(rejection_id, username=user.username, db=db)
+    resolved = await rejections_db.resolve(
+        rejection_id, username=user.username, db=db,
+        resolution=body.resolution if body else None,
+    )
     return {
         "success": True,
         "message": f"Rejection {rejection_id} resolved.",

--- a/app/schemas/annotation_queue.py
+++ b/app/schemas/annotation_queue.py
@@ -1,0 +1,61 @@
+"""Schemas for the annotation queue: the persisted order an annotator works in.
+
+The queue lets an annotator pick how a dataset's images are ordered before the
+editor opens — as uploaded, randomized, or a future active-learning ordering — and
+the choice is saved per (dataset, user) so re-entering resumes it. Ordering is
+delegated to a strategy registry (see ``app.services.annotation_queue``) so that
+active-learning scorers can be added without touching this request/response
+contract, exactly as the review queue does for its own orderings.
+"""
+from __future__ import annotations
+
+from datetime import datetime
+
+from pydantic import BaseModel, Field
+
+
+class AnnotationQueueRequest(BaseModel):
+    """Request body for building (and saving) an annotation queue."""
+
+    strategy: str = Field(
+        ...,
+        description="Key of the ordering strategy to build the queue with. The "
+                    "available keys are listed in the annotation-queue summary; "
+                    "only strategies flagged `available` can be built.",
+    )
+
+
+class AnnotationQueueStrategyOption(BaseModel):
+    """One selectable queue ordering, for the builder's option list."""
+
+    key: str
+    label: str
+    description: str
+    available: bool = Field(
+        True,
+        description="False for orderings shown as a placeholder (e.g. active "
+                    "learning) that cannot be built yet.",
+    )
+
+
+class AnnotationQueueRead(BaseModel):
+    """A saved annotation queue: image ids in the order they will be worked."""
+
+    strategy: str
+    image_ids: list[int] = Field(default_factory=list)
+    total: int
+    updated_at: datetime | None = None
+
+
+class AnnotationQueueSummary(BaseModel):
+    """The dataset's annotation workload plus queue state, for the card and builder."""
+
+    not_started: int = Field(..., description="Images whose mask is not started.")
+    in_progress: int = Field(..., description="Images whose mask is in progress.")
+    finished: int = Field(..., description="Images whose mask is finished.")
+    total: int = Field(..., description="Total images in the dataset.")
+    has_saved_queue: bool = Field(..., description="Whether the caller has a saved queue here.")
+    saved_strategy: str | None = Field(
+        None, description="Strategy of the saved queue, if any."
+    )
+    strategies: list[AnnotationQueueStrategyOption] = Field(default_factory=list)

--- a/app/schemas/review.py
+++ b/app/schemas/review.py
@@ -31,6 +31,19 @@ class RejectionReason(StrEnum):
     OTHER = "other"
 
 
+class RejectionResolution(StrEnum):
+    """How a rejection was closed.
+
+    Recorded when the annotator works through the correction queue: ``FIXED`` means
+    the annotation was reworked, ``WONT_FIX`` means it was looked at and left as is
+    ("I checked, it is correct"). NULL on rows resolved before this vocabulary
+    existed, so callers must treat a missing resolution as "unspecified".
+    """
+
+    FIXED = "fixed"
+    WONT_FIX = "wont_fix"
+
+
 #: Human-readable labels for the frontend, so the wording lives with the enum.
 REJECTION_REASON_LABELS: dict[RejectionReason, str] = {
     RejectionReason.BAD_OUTLINE: "Outline is inaccurate",
@@ -65,6 +78,20 @@ class RejectionCreate(BaseModel):
         return self
 
 
+class RejectionResolve(BaseModel):
+    """Request body for resolving a rejection.
+
+    The body is optional on the wire (an empty PATCH still resolves); ``resolution``
+    records *how* it was closed when the caller knows, e.g. the correction queue's
+    "Mark as done" (``fixed``) versus "Won't fix" (``wont_fix``).
+    """
+
+    resolution: RejectionResolution | None = Field(
+        None,
+        description="How the rejection was closed. Omit for an unspecified resolve.",
+    )
+
+
 class RejectionRead(BaseModel):
     """A rejection as returned to the client."""
 
@@ -78,6 +105,7 @@ class RejectionRead(BaseModel):
     created_at: datetime
     resolved_at: datetime | None
     resolved_by: str | None
+    resolution: RejectionResolution | None = None
 
     @property
     def is_open(self) -> bool:
@@ -90,6 +118,214 @@ class RejectionReasonOption(BaseModel):
     value: RejectionReason
     label: str
     requires_note: bool
+
+
+# -- Review queue -----------------------------------------------------------
+#
+# The queue is how a reviewer works through pending annotations: they pick a
+# granularity (whole images, or one instance at a time) and an ordering, and the
+# backend returns the work items in that order. Ordering is delegated to a
+# strategy registry (see `app.services.review_queue`) so that active-learning
+# scorers (uncertainty, disagreement, ...) can be added without touching the
+# request/response contract: a strategy only has to map each candidate to a score.
+
+
+class ReviewGranularity(StrEnum):
+    """What one queue item spans."""
+
+    #: One item per image: the whole mask with all its contours at once.
+    IMAGES = "images"
+    #: One item per instance, ordered by the contour hierarchy (roots first).
+    HIERARCHY = "hierarchy"
+    #: One item per instance, restricted to a chosen set of labels.
+    CUSTOM = "custom"
+
+
+class ReviewSortDirection(StrEnum):
+    ASCENDING = "asc"
+    DESCENDING = "desc"
+
+
+class ReviewQueueRequest(BaseModel):
+    """Request body for building a review queue."""
+
+    granularity: ReviewGranularity = Field(..., description="What one queue item spans.")
+    sort_strategy: str = Field(
+        "hierarchy",
+        description="Key of the scoring strategy that orders instance items. "
+                    "The available keys are listed in the review summary.",
+    )
+    direction: ReviewSortDirection = Field(
+        ReviewSortDirection.ASCENDING,
+        description="Ascending replays the strategy's natural order "
+                    "(for 'hierarchy': root instances first).",
+    )
+    label_ids: list[int] | None = Field(
+        None,
+        description="Only queue instances carrying one of these labels. "
+                    "Required for 'custom' granularity, ignored otherwise.",
+    )
+    only_submitted: bool = Field(
+        True,
+        description="Only queue work from masks submitted for review "
+                    "(fully annotated, no open rejections). Turn off to also "
+                    "sweep through work still in progress.",
+    )
+    include_reviewed: bool = Field(
+        False,
+        description="Also queue instances that already carry an approval — the "
+                    "caller's own included, so a solo reviewer can re-sweep their "
+                    "work. Re-accepting is a no-op; rejecting withdraws the "
+                    "caller's earlier approval of that instance.",
+    )
+
+    @model_validator(mode="after")
+    def _require_labels_for_custom(self) -> "ReviewQueueRequest":
+        if self.granularity is ReviewGranularity.CUSTOM and not self.label_ids:
+            raise ValueError("Custom review needs at least one label to filter by.")
+        return self
+
+
+class ReviewQueueImageItem(BaseModel):
+    """One whole-image work item."""
+
+    image_id: int
+    mask_id: int
+    pending_instances: int = Field(..., description="Contours nobody has approved yet.")
+    total_instances: int
+
+
+class ReviewQueueInstanceItem(BaseModel):
+    """One single-instance work item.
+
+    Geometry is deliberately not included — the player fetches the mask's contours
+    once (they carry the SVG paths) and picks this instance plus its immediate
+    children out of that list via `parent_id`.
+    """
+
+    contour_id: int
+    mask_id: int
+    image_id: int
+    label_id: int | None
+    parent_id: int | None
+    depth: int = Field(..., description="0 for root instances.")
+    score: float = Field(..., description="The sort strategy's score for this instance.")
+
+
+class ReviewQueueRead(BaseModel):
+    """A freshly built review queue.
+
+    Exactly one of `images` / `instances` is populated, depending on granularity.
+    The queue is a snapshot: it is not persisted server-side, so a stale entry
+    (e.g. approved by someone else meanwhile) simply no-ops during the session.
+    """
+
+    granularity: ReviewGranularity
+    sort_strategy: str
+    direction: ReviewSortDirection
+    # Echoed back so the session can keep acting under the same rules it was
+    # built with (e.g. the image-level Accept must match the queue's eligibility).
+    include_reviewed: bool = False
+    total: int
+    images: list[ReviewQueueImageItem] = Field(default_factory=list)
+    instances: list[ReviewQueueInstanceItem] = Field(default_factory=list)
+
+
+class ReviewSortStrategyOption(BaseModel):
+    """One selectable queue ordering, for the setup page's dropdown."""
+
+    key: str
+    label: str
+    description: str
+
+
+class ReviewSummary(BaseModel):
+    """The dataset's review workload, for the management card and setup page."""
+
+    pending_instances: int = Field(..., description="Unapproved contours on submitted masks.")
+    pending_images: int = Field(..., description="Images with at least one pending instance.")
+    reviewed_instances: int = Field(
+        0,
+        description="Already-approved contours on submitted masks — re-reviewable "
+                    "via the queue's include_reviewed option.",
+    )
+    open_rejections: int = Field(..., description="Sent-back items the annotators have not addressed yet.")
+    strategies: list[ReviewSortStrategyOption] = Field(default_factory=list)
+
+
+# -- Correction queue -------------------------------------------------------
+#
+# The mirror image of the review queue: where the review queue serves *pending*
+# annotations to a reviewer, the correction queue serves *sent-back* annotations
+# (open rejections) to an annotator, who works through them in the editor. Each
+# item points at the mask/contour to load and carries the reviewer's reason and
+# note so the annotator knows what to fix. Resolving an item (fixed / won't fix)
+# closes the rejection; the queue is a snapshot, so an item someone else resolved
+# meanwhile simply no-ops when acted on — the same contract as the review queue.
+
+
+class CorrectionSortOrder(StrEnum):
+    """The order corrections are served in. There is no scoring registry: unlike
+    review, corrections are a flat worklist, walked front to back by age."""
+
+    OLDEST = "oldest"
+    NEWEST = "newest"
+
+
+class CorrectionQueueRequest(BaseModel):
+    """Request body for building a correction queue."""
+
+    order: CorrectionSortOrder = Field(
+        CorrectionSortOrder.OLDEST,
+        description="Oldest feedback first (clear the backlog) or newest first.",
+    )
+    reasons: list[RejectionReason] | None = Field(
+        None,
+        description="Only queue rejections carrying one of these reasons. "
+                    "Omit (or empty) to queue every open rejection.",
+    )
+
+
+class CorrectionQueueItem(BaseModel):
+    """One sent-back item to correct.
+
+    ``contour_id`` is null for a mask-level rejection (e.g. "objects are missing"),
+    which the editor handles by loading the image without pre-selecting an object.
+    """
+
+    rejection_id: int
+    mask_id: int
+    image_id: int
+    contour_id: int | None
+    reason: RejectionReason
+    reason_label: str
+    note: str | None
+    created_by: str | None
+    created_at: datetime
+
+
+class CorrectionQueueRead(BaseModel):
+    """A freshly built correction queue.
+
+    Items on the same image are consecutive so the editor's per-image session and
+    caches carry across them, matching the review queue's grouping. The queue is a
+    snapshot: it is not persisted, so a stale entry (resolved by someone else
+    meanwhile) simply no-ops when acted on.
+    """
+
+    order: CorrectionSortOrder
+    total: int
+    items: list[CorrectionQueueItem] = Field(default_factory=list)
+
+
+class CorrectionSummary(BaseModel):
+    """The dataset's correction workload, for the management card and launch page."""
+
+    open_rejections: int = Field(..., description="Sent-back items not yet resolved.")
+    affected_instances: int = Field(
+        ..., description="Distinct contours with an open rejection (mask-level ones excluded)."
+    )
+    affected_images: int = Field(..., description="Images with at least one open rejection.")
 
 
 class MemberRead(BaseModel):

--- a/app/services/annotation_queue.py
+++ b/app/services/annotation_queue.py
@@ -1,0 +1,202 @@
+"""Building and persisting annotation queues: the order an annotator works images.
+
+Mirrors ``app.services.review_queue`` but with two deliberate differences:
+
+* **Whole-image ordering, not instance scoring.** A strategy maps the dataset's
+  images (in upload order) to an ordered list of image ids — there is nothing to
+  score per contour.
+* **Persisted, not a snapshot.** The built order is saved per (dataset, user) in
+  ``annotation_queues`` so re-entering resumes it; rebuilding overwrites the row.
+
+Orderings live in a registry so an active-learning ordering (e.g. diversity
+sampling) can be added without touching the request/response contract: register a
+strategy and it appears in the builder. A strategy may be registered as a
+*placeholder* (``available=False``) — it shows in the UI but cannot be built yet.
+"""
+from __future__ import annotations
+
+import random
+from dataclasses import dataclass
+from typing import Callable
+
+from fastapi import HTTPException, status
+from sqlalchemy import func
+from sqlalchemy.orm import Session
+
+from app.database.annotation_queues import AnnotationQueues
+from app.database.images import Images
+from app.database.masks import Masks
+from app.schemas.annotation_queue import (
+    AnnotationQueueRead,
+    AnnotationQueueStrategyOption,
+    AnnotationQueueSummary,
+)
+
+#: An ordering strategy: uploaded-order image ids -> queue-order image ids. Must be
+#: pure; it runs once at build time.
+OrderFn = Callable[[list[int]], list[int]]
+
+
+@dataclass(frozen=True)
+class QueueStrategy:
+    key: str
+    label: str
+    description: str
+    available: bool
+    order: OrderFn | None  # None for placeholder strategies.
+
+
+SORT_STRATEGIES: dict[str, QueueStrategy] = {}
+
+
+def register_strategy(key: str, label: str, description: str, available: bool = True):
+    """Register a queue ordering. Registered keys appear in the builder."""
+
+    def decorator(fn: OrderFn) -> OrderFn:
+        SORT_STRATEGIES[key] = QueueStrategy(
+            key=key, label=label, description=description, available=available, order=fn
+        )
+        return fn
+
+    return decorator
+
+
+@register_strategy(
+    "as_uploaded",
+    "As uploaded",
+    "Annotate images in the order they were added to the dataset.",
+)
+def _order_as_uploaded(image_ids: list[int]) -> list[int]:
+    return list(image_ids)
+
+
+@register_strategy(
+    "random",
+    "Randomized order",
+    "Shuffle the images. The order is fixed once built, so it stays stable across sessions.",
+)
+def _order_random(image_ids: list[int]) -> list[int]:
+    shuffled = list(image_ids)
+    random.shuffle(shuffled)
+    return shuffled
+
+
+@register_strategy(
+    "diversity",
+    "Diversity sampling (active learning)",
+    "Order images to maximise visual diversity early on. Coming soon.",
+    available=False,
+)
+def _order_diversity(image_ids: list[int]) -> list[int]:  # pragma: no cover - placeholder
+    raise HTTPException(
+        status_code=status.HTTP_400_BAD_REQUEST,
+        detail="The diversity-sampling ordering is not available yet.",
+    )
+
+
+def strategy_options() -> list[AnnotationQueueStrategyOption]:
+    return [
+        AnnotationQueueStrategyOption(
+            key=s.key, label=s.label, description=s.description, available=s.available
+        )
+        for s in SORT_STRATEGIES.values()
+    ]
+
+
+def _uploaded_image_ids(dataset_id: int, db: Session) -> list[int]:
+    """The dataset's image ids in upload order (ascending id)."""
+    rows = (
+        db.query(Images.id)
+        .filter(Images.dataset_id == dataset_id)
+        .order_by(Images.id.asc())
+        .all()
+    )
+    return [image_id for (image_id,) in rows]
+
+
+def _status_counts(dataset_id: int, db: Session) -> dict[str, int]:
+    """Per-status image counts for the dataset, from each image's mask."""
+    rows = (
+        db.query(Masks.status, func.count(Masks.id))
+        .join(Images, Images.id == Masks.image_id)
+        .filter(Images.dataset_id == dataset_id)
+        .group_by(Masks.status)
+        .all()
+    )
+    return {mask_status: count for mask_status, count in rows}
+
+
+def get_saved_queue(dataset_id: int, username: str, db: Session) -> AnnotationQueueRead | None:
+    """The caller's saved queue for the dataset, or None if they have not built one."""
+    row = (
+        db.query(AnnotationQueues)
+        .filter(AnnotationQueues.dataset_id == dataset_id,
+                AnnotationQueues.username == username)
+        .one_or_none()
+    )
+    if row is None:
+        return None
+    image_ids = list(row.image_order or [])
+    return AnnotationQueueRead(
+        strategy=row.strategy,
+        image_ids=image_ids,
+        total=len(image_ids),
+        updated_at=row.updated_at,
+    )
+
+
+def build_and_save_queue(
+    dataset_id: int, username: str, strategy_key: str, db: Session
+) -> AnnotationQueueRead:
+    """Build the ordered image list for the strategy and persist it (upsert)."""
+    strategy = SORT_STRATEGIES.get(strategy_key)
+    if strategy is None:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=f"Unknown ordering '{strategy_key}'. "
+                   f"Available: {sorted(SORT_STRATEGIES)}.",
+        )
+    if not strategy.available or strategy.order is None:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=f"The '{strategy_key}' ordering is not available yet.",
+        )
+
+    ordered_ids = strategy.order(_uploaded_image_ids(dataset_id, db))
+
+    row = (
+        db.query(AnnotationQueues)
+        .filter(AnnotationQueues.dataset_id == dataset_id,
+                AnnotationQueues.username == username)
+        .one_or_none()
+    )
+    if row is None:
+        row = AnnotationQueues(dataset_id=dataset_id, username=username)
+        db.add(row)
+    row.strategy = strategy_key
+    row.image_order = ordered_ids
+    db.commit()
+    db.refresh(row)
+
+    return AnnotationQueueRead(
+        strategy=row.strategy,
+        image_ids=list(row.image_order or []),
+        total=len(row.image_order or []),
+        updated_at=row.updated_at,
+    )
+
+
+def summarize(dataset_id: int, username: str, db: Session) -> AnnotationQueueSummary:
+    """Counts behind the Annotation card's subcaption plus the saved-queue state."""
+    counts = _status_counts(dataset_id, db)
+    total = db.query(func.count(Images.id)).filter(Images.dataset_id == dataset_id).scalar() or 0
+    saved = get_saved_queue(dataset_id, username, db)
+    return AnnotationQueueSummary(
+        not_started=counts.get("not_started", 0),
+        in_progress=counts.get("in_progress", 0),
+        finished=counts.get("finished", 0),
+        total=total,
+        has_saved_queue=saved is not None,
+        saved_strategy=saved.strategy if saved else None,
+        strategies=strategy_options(),
+    )

--- a/app/services/correction_queue.py
+++ b/app/services/correction_queue.py
@@ -1,0 +1,119 @@
+"""Building correction queues: which sent-back annotations an annotator has to
+address, in what order.
+
+The mirror image of ``app.services.review_queue``. Where the review queue collects
+*pending* contours for a reviewer, the correction queue collects *open rejections*
+(the reviewer's send-backs) for the annotator who has to rework them. An item points
+at the mask — and, for a per-object complaint, the contour — to load in the editor,
+and carries the reviewer's reason and note so the annotator knows what to change.
+
+Every open rejection in the dataset qualifies (the send-back is dataset-wide work,
+not scoped to one author — same visibility as ``RejectionBanner``). Ordering is a
+flat oldest/newest-first sort, not a scoring registry: corrections are a backlog to
+clear, not a ranked review pass. Items are grouped so an image's rejections stay
+consecutive, keeping the editor's per-image session and caches warm across them.
+
+Queues are snapshots, not reservations: nothing is locked, and an item someone else
+resolves mid-session simply no-ops when acted on.
+"""
+from __future__ import annotations
+
+from datetime import datetime
+
+from sqlalchemy.orm import Session
+
+from app.database.images import Images
+from app.database.masks import Masks
+from app.database.rejections import AnnotationRejections
+from app.schemas.review import (
+    REJECTION_REASON_LABELS,
+    CorrectionQueueItem,
+    CorrectionQueueRead,
+    CorrectionQueueRequest,
+    CorrectionSortOrder,
+    CorrectionSummary,
+    RejectionReason,
+)
+
+#: Sort sentinel for a rejection with no timestamp (never expected on an open row).
+_MIN_TIME = datetime.min
+
+
+def _open_rejections_query(dataset_id: int, db: Session):
+    """Open rejections of the dataset, with each one's image id.
+
+    Joined through ``Masks`` to ``Images`` both to scope to the dataset and to
+    surface the image id: a rejection names a mask, and the editor loads by image.
+    """
+    return (
+        db.query(
+            AnnotationRejections.id,
+            AnnotationRejections.mask_id,
+            AnnotationRejections.contour_id,
+            AnnotationRejections.reason,
+            AnnotationRejections.note,
+            AnnotationRejections.created_by,
+            AnnotationRejections.created_at,
+            Masks.image_id.label("image_id"),
+        )
+        .join(Masks, Masks.id == AnnotationRejections.mask_id)
+        .join(Images, Images.id == Masks.image_id)
+        .filter(Images.dataset_id == dataset_id,
+                AnnotationRejections.resolved_at.is_(None))
+    )
+
+
+def summarize(dataset_id: int, db: Session) -> CorrectionSummary:
+    """The numbers behind "There are x instances sent back for correction"."""
+    rows = _open_rejections_query(dataset_id, db).all()
+    return CorrectionSummary(
+        open_rejections=len(rows),
+        affected_instances=len({row.contour_id for row in rows
+                                if row.contour_id is not None}),
+        affected_images=len({row.image_id for row in rows}),
+    )
+
+
+def build_queue(dataset_id: int, request: CorrectionQueueRequest,
+                db: Session) -> CorrectionQueueRead:
+    """Build the ordered work list for one correction session."""
+    rows = _open_rejections_query(dataset_id, db).all()
+
+    if request.reasons:
+        wanted = {reason.value for reason in request.reasons}
+        rows = [row for row in rows if row.reason in wanted]
+
+    newest_first = request.order is CorrectionSortOrder.NEWEST
+
+    # Group an image's rejections together, but order the images themselves by the
+    # age of their leading item so "oldest first" still walks the backlog in age
+    # order across images (not by image id). `created_at` is None-guarded for
+    # safety — an open rejection always has one — with a stable minimum sentinel.
+    def age(row):
+        return row.created_at or _MIN_TIME
+
+    image_key: dict[int, object] = {}
+    for row in rows:
+        current = image_key.get(row.image_id)
+        candidate = age(row)
+        if current is None or (candidate > current if newest_first else candidate < current):
+            image_key[row.image_id] = candidate
+
+    rows.sort(key=lambda row: (image_key[row.image_id], row.image_id, age(row)),
+              reverse=newest_first)
+
+    items = [
+        CorrectionQueueItem(
+            rejection_id=row.id,
+            mask_id=row.mask_id,
+            image_id=row.image_id,
+            contour_id=row.contour_id,
+            reason=RejectionReason(row.reason),
+            reason_label=REJECTION_REASON_LABELS[RejectionReason(row.reason)],
+            note=row.note,
+            created_by=row.created_by,
+            created_at=row.created_at,
+        )
+        for row in rows
+    ]
+    return CorrectionQueueRead(order=request.order, total=len(items), items=items)

--- a/app/services/database_access/contours.py
+++ b/app/services/database_access/contours.py
@@ -14,6 +14,7 @@ from app.database.contours import (
 from app.database.datasets import Datasets
 from app.database.images import Images
 from app.database.masks import Masks
+from app.database.rejections import AnnotationRejections
 from app.database.users import Users
 from app.services.database_access.labels import get_label_hierarchy
 from app.services.quantification import (
@@ -63,59 +64,6 @@ def mark_relational_stale_for_parent(
     if parent_id is None:
         return 0
     return mark_relational_stale(db, [parent_id])
-
-
-def _sibling_ids(db: Session, mask_id: int, parent_id: int | None) -> list[int]:
-    """All contour ids sharing ``(mask_id, parent_id)`` (None = root level of that image)."""
-    query = db.query(Contours.id).filter(Contours.mask_id == mask_id)
-    query = query.filter(Contours.parent_id.is_(None)) if parent_id is None else query.filter(
-        Contours.parent_id == parent_id
-    )
-    return [row.id for row in query.all()]
-
-
-def mark_contextual_stale_for_group(
-        db: Session,
-        contour_id: int,
-        mask_id: int | None = None,
-        parent_id: int | None = None,
-) -> int:
-    """Mark CONTEXTUAL-tier rows stale for ``contour_id`` AND all of its same-parent siblings.
-
-    Nearest-neighbour-style metrics are relational: every contour in a parent group is a
-    potential neighbor of every other, so a change to ONE contour (moved, re-parented,
-    added, or removed) invalidates the correct value for ALL of them, not just itself -
-    the KDTree for the group has to be rebuilt regardless of which member changed.
-
-    ``mask_id`` / ``parent_id`` can be passed explicitly for callers that already know
-    them (e.g. ``delete_contour``, which must capture them BEFORE the delete removes the
-    row, and ``modify_contour`` when ``parent_id`` itself changed - both the OLD and the
-    NEW group need invalidating). When omitted, they are looked up from ``contour_id``;
-    if the contour cannot be found either way, only ``contour_id`` itself is marked
-    (harmless - a missing contour has no siblings left to protect).
-
-    Args:
-        db: The database session (caller controls commit).
-        contour_id: The contour whose parent group should be invalidated. Marked stale
-            itself even if it no longer exists in ``contours`` (ON DELETE CASCADE will
-            already have removed its own rows in that case, so this is a no-op for it,
-            but siblings still get marked correctly).
-        mask_id: The contour's ``mask_id``, if already known (avoids a lookup).
-        parent_id: The contour's ``parent_id`` (None = root level), if already known.
-
-    Returns:
-        The number of ``contour_metrics`` rows marked stale.
-    """
-    if mask_id is None:
-        contour_db = db.query(Contours).filter_by(id=contour_id).one_or_none()
-        if contour_db is None:
-            return mark_contextual_stale(db, [contour_id])
-        mask_id = contour_db.mask_id
-        parent_id = contour_db.parent_id
-
-    ids = set(_sibling_ids(db, mask_id, parent_id))
-    ids.add(contour_id)
-    return mark_contextual_stale(db, ids)
 
 
 # --- Metric staleness invalidation -------------------------------------------------
@@ -344,11 +292,6 @@ async def delete_contour(
     # Delete the root contour (CASCADE will handle the rest)
     db.delete(contour)
     db.flush()
-    mark_contextual_stale_for_group(db, contour_id, mask_id=mask_id, parent_id=parent_id)
-    # RELATIONAL: the deleted contour's PARENT (if any) just lost a child, so its
-    # n_children row is stale (parent-targeted, unlike the sibling-group contextual
-    # invalidation above). The deleted contour's own relational row is gone via CASCADE.
-    mark_relational_stale_for_parent(db, parent_id)
     db.commit()
 
 
@@ -419,18 +362,17 @@ async def modify_contour(
         # x/y move the centroid, parent_id re-parents into a different sibling group,
         # label_id affects any future label-filtered contextual variant (see Step 5
         # notes) - any of these invalidate the contour's (new) parent group.
-        mark_contextual_stale_for_group(db, contour_id, mask_id=contour_db.mask_id, parent_id=contour_db.parent_id)
+        mark_contextual_stale_for_group(db, contour_db.mask_id, contour_db.parent_id)
         if "parent_id" in kwargs and old_parent_id != contour_db.parent_id:
             # Re-parenting also invalidates the OLD group it left (one fewer sibling).
-            mark_contextual_stale_for_group(db, contour_id, mask_id=old_mask_id, parent_id=old_parent_id)
+            mark_contextual_stale_for_group(db, contour_db.mask_id, old_parent_id)
 
     if "parent_id" in kwargs and old_parent_id != contour_db.parent_id:
         # RELATIONAL: re-parenting moves this contour from one parent's child set to
         # another's, so BOTH the old parent (lost a child) and the new parent (gained one)
         # have a stale n_children count. Parent-targeted only - neither parent's siblings
         # are affected. None parents (root level) are no-ops.
-        mark_relational_stale_for_parent(db, old_parent_id)
-        mark_relational_stale_for_parent(db, contour_db.parent_id)
+        mark_relational_stale_for_parent(db, [old_parent_id, contour_db.parent_id])
 
     db.flush()
 
@@ -505,10 +447,34 @@ async def replace_contour(
     # contour's geometry does not silently reassign who is credited with it.
     author_username = author_username or contour.author_username
     mask_id, parent_id = contour.mask_id, contour.parent_id
+
+    # A replace is delete + re-insert under the SAME id — logically an in-place
+    # geometry update (e.g. an outline refinement), not a real deletion. But the
+    # DELETE fires the ON DELETE CASCADE on annotation_rejections.contour_id, which
+    # would wipe the reviewer's open send-backs for this object — and in the
+    # correction queue, 404 the "Mark as done" that follows the fix. Detach the
+    # rejections across the swap and re-point them to the reused id, so both the
+    # rejections and their ids survive the geometry change.
+    rejection_ids = [
+        rid for (rid,) in
+        db.query(AnnotationRejections.id).filter_by(contour_id=old_contour_id).all()
+    ]
+    if rejection_ids:
+        db.query(AnnotationRejections).filter(
+            AnnotationRejections.id.in_(rejection_ids)
+        ).update({AnnotationRejections.contour_id: None}, synchronize_session=False)
+        db.flush()
+
     db.query(Contours).filter_by(id=old_contour_id).delete()
-    save_contour_tree(db, new_contour_model, contour.mask_id, contour.parent_id,
+    save_contour_tree(db, new_contour_model, mask_id, parent_id,
                       author_username=author_username)
-    save_contour_tree(db, new_contour_model, mask_id, parent_id)
+
+    if rejection_ids:
+        # The contour keeps its id (set above), so the FK is valid again.
+        db.query(AnnotationRejections).filter(
+            AnnotationRejections.id.in_(rejection_ids)
+        ).update({AnnotationRejections.contour_id: old_contour_id},
+                 synchronize_session=False)
     # The contour keeps its id but its geometry (and therefore its filled pixels) is
     # entirely new; any appearance rows written above the delete's CASCADE (none should
     # remain, since the CASCADE removed them with the old contour row) must not be
@@ -520,6 +486,6 @@ async def replace_contour(
     # recomputing. save_contour_tree only dual-writes GEOMETRY rows for the new contour;
     # contextual staleness for the group is marked here explicitly, mirroring
     # mark_appearance_stale above.
-    mark_contextual_stale_for_group(db, old_contour_id, mask_id=mask_id, parent_id=parent_id)
+    mark_contextual_stale_for_group(db, mask_id, parent_id)
     db.commit()
     return True

--- a/app/services/database_access/images.py
+++ b/app/services/database_access/images.py
@@ -119,6 +119,11 @@ async def backfill_image_dimensions(
     Pass ``dataset_id`` to limit the repair to a single dataset; otherwise every
     image is checked. Returns the ids that were corrected and any whose original
     file is missing.
+
+    Geometry metrics (area, perimeter, ...) of the affected contours are
+    recomputed as well: they were derived in pixel space from the wrong
+    dimensions, so they are off by the same factor squared. The normalized
+    contour coordinates themselves are dimension-free and stay untouched.
     """
     query = db.query(Images)
     if dataset_id is not None:
@@ -140,9 +145,32 @@ async def backfill_image_dimensions(
             image.height = height
             corrected.append(image.id)
 
+    recomputed_contours = 0
     if corrected:
         db.commit()
-    return {"corrected": corrected, "missing": missing}
+        recomputed_contours = _recompute_geometry_for_images(db, corrected)
+        db.commit()
+    return {"corrected": corrected, "missing": missing,
+            "recomputed_contours": recomputed_contours}
+
+
+def _recompute_geometry_for_images(db: Session, image_ids: list[int]) -> int:
+    """Re-derive the geometry metrics of every contour on the given images.
+
+    Reuses the write path's dual-write (legacy columns + tall ``contour_metrics``
+    rows), so the repaired values land in both stores consistently.
+    """
+    from app.database.contours import Contours, dual_write_geometry_metrics
+
+    recomputed = 0
+    masks = db.query(Masks).filter(Masks.image_id.in_(image_ids)).all()
+    for mask in masks:
+        contours = db.query(Contours).filter_by(mask_id=mask.id).all()
+        if not contours:
+            continue
+        dual_write_geometry_metrics(db, mask.id, contours)
+        recomputed += len(contours)
+    return recomputed
 
 
 async def delete_image(

--- a/app/services/database_access/rejections.py
+++ b/app/services/database_access/rejections.py
@@ -14,6 +14,7 @@ from app.schemas.review import (
     RejectionRead,
     RejectionReason,
     RejectionReasonOption,
+    RejectionResolution,
 )
 
 logger = getLogger(__name__)
@@ -58,6 +59,7 @@ def to_read(rejection: AnnotationRejections) -> RejectionRead:
         created_at=_as_utc(rejection.created_at),
         resolved_at=_as_utc(rejection.resolved_at),
         resolved_by=rejection.resolved_by,
+        resolution=RejectionResolution(rejection.resolution) if rejection.resolution else None,
     )
 
 
@@ -70,20 +72,27 @@ async def reject(mask_id: int,
     Rejecting also clears `fully_annotated`, so the mask leaves the reviewer's
     queue and reappears in the annotator's; without that the same mask would keep
     showing up as awaiting review.
+
+    Rejecting a specific contour additionally withdraws the rejecting reviewer's
+    own earlier approval of it (if any): a reviewer who changed their mind on a
+    re-review pass overwrites their old verdict rather than holding both. Other
+    reviewers' approvals are left alone — they were somebody else's judgement.
     """
     mask = db.query(Masks).filter_by(id=mask_id).first()
     if mask is None:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Mask not found.")
 
     if body.contour_id is not None:
-        belongs = (
-            db.query(Contours.id)
+        contour = (
+            db.query(Contours)
             .filter(Contours.id == body.contour_id, Contours.mask_id == mask_id)
-            .scalar()
+            .first()
         )
-        if belongs is None:
+        if contour is None:
             raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST,
                                 detail=f"Contour {body.contour_id} does not belong to mask {mask_id}.")
+        contour.reviewed_by = [reviewer for reviewer in contour.reviewed_by
+                               if reviewer.username != username]
 
     rejection = AnnotationRejections(
         mask_id=mask_id,
@@ -100,14 +109,21 @@ async def reject(mask_id: int,
     return rejection
 
 
-async def resolve(rejection_id: int, username: str, db: Session) -> AnnotationRejections:
-    """Mark one rejection as dealt with. Resolving is idempotent."""
+async def resolve(rejection_id: int, username: str, db: Session,
+                  resolution: RejectionResolution | None = None) -> AnnotationRejections:
+    """Mark one rejection as dealt with. Resolving is idempotent.
+
+    ``resolution`` records how it was closed (``fixed`` / ``wont_fix``) when the
+    caller knows; it is only written on the first resolve, so re-resolving an
+    already-closed rejection never overwrites the original verdict.
+    """
     rejection = db.query(AnnotationRejections).filter_by(id=rejection_id).first()
     if rejection is None:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Rejection not found.")
     if rejection.resolved_at is None:
         rejection.resolved_at = _utcnow()
         rejection.resolved_by = username
+        rejection.resolution = resolution.value if resolution else None
         db.commit()
         db.refresh(rejection)
     return rejection

--- a/app/services/review_queue.py
+++ b/app/services/review_queue.py
@@ -1,0 +1,315 @@
+"""Building review queues: which annotations need eyes on them, in what order.
+
+The queue has two halves:
+
+* **Candidate collection** — every non-temporary contour of the dataset whose mask
+  is review-ready (submitted and without open rejections, unless the caller asks
+  for in-progress work too). By default only contours nobody has approved yet
+  qualify; with `include_reviewed` every contour qualifies, the caller's own past
+  approvals included — a solo reviewer must be able to re-sweep their own work.
+  Re-accepting is a no-op (approvals are a set); rejecting a previously approved
+  contour withdraws the rejecting reviewer's own approval (see
+  `database_access.rejections.reject`), so a changed mind overwrites the old
+  verdict instead of coexisting with it.
+* **Ordering** — a scoring strategy from `SORT_STRATEGIES` maps each candidate to a
+  float; the queue is the candidates sorted by that score. "Hierarchy" (score =
+  nesting depth, so root instances come first) is the default. Active-learning
+  orderings plug in here: registering a new strategy is all it takes for it to
+  show up in the setup page's dropdown, the API contract does not change.
+
+Queues are snapshots, not reservations: nothing is locked server-side, and an item
+that someone else approves mid-session simply becomes a no-op when acted on.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Callable
+
+from fastapi import HTTPException, status
+from sqlalchemy.orm import Session
+
+from app.database.contours import Contours
+from app.database.images import Images
+from app.database.labels import Labels
+from app.database.masks import Masks
+from app.database.rejections import AnnotationRejections
+from app.schemas.review import (
+    ReviewGranularity,
+    ReviewQueueImageItem,
+    ReviewQueueInstanceItem,
+    ReviewQueueRead,
+    ReviewQueueRequest,
+    ReviewSortDirection,
+    ReviewSortStrategyOption,
+    ReviewSummary,
+)
+
+
+@dataclass
+class QueueCandidate:
+    """One contour under consideration, with everything a scorer may need."""
+
+    contour_id: int
+    mask_id: int
+    image_id: int
+    label_id: int | None
+    parent_id: int | None
+    depth: int
+    confidence: float
+    reviewed: bool  # True once anyone has approved it.
+
+    @property
+    def pending(self) -> bool:
+        """Untouched by any reviewer — the default queue's eligibility."""
+        return not self.reviewed
+
+    def eligible(self, include_reviewed: bool) -> bool:
+        """Whether this contour belongs in the queue.
+
+        `include_reviewed` re-opens everything, own approvals included, so a solo
+        reviewer can re-sweep work they already signed off on.
+        """
+        return include_reviewed or not self.reviewed
+
+
+#: A scoring strategy: candidate -> sort key. Lower scores are served first when
+#: the direction is ascending. Strategies must be pure and cheap — they run once
+#: per candidate at queue-build time.
+ScoreFn = Callable[[QueueCandidate], float]
+
+
+@dataclass(frozen=True)
+class SortStrategy:
+    key: str
+    label: str
+    description: str
+    score: ScoreFn
+
+
+SORT_STRATEGIES: dict[str, SortStrategy] = {}
+
+
+def register_strategy(key: str, label: str, description: str):
+    """Register a queue ordering. Registered keys appear in the setup UI."""
+
+    def decorator(fn: ScoreFn) -> ScoreFn:
+        SORT_STRATEGIES[key] = SortStrategy(key=key, label=label,
+                                            description=description, score=fn)
+        return fn
+
+    return decorator
+
+
+@register_strategy(
+    "hierarchy",
+    "By hierarchy",
+    "Root instances first, then their children — verify containers before contents.",
+)
+def _score_by_depth(candidate: QueueCandidate) -> float:
+    return float(candidate.depth)
+
+
+@register_strategy(
+    "uncertainty",
+    "By model confidence",
+    "Least confident instances first. Manual annotations (confidence 1.0) come last.",
+)
+def _score_by_confidence(candidate: QueueCandidate) -> float:
+    return float(candidate.confidence)
+
+
+def strategy_options() -> list[ReviewSortStrategyOption]:
+    return [
+        ReviewSortStrategyOption(key=s.key, label=s.label, description=s.description)
+        for s in SORT_STRATEGIES.values()
+    ]
+
+
+# -- Candidate collection ----------------------------------------------------
+
+def _open_rejection_mask_ids(dataset_id: int, db: Session) -> set[int]:
+    rows = (
+        db.query(AnnotationRejections.mask_id)
+        .join(Masks, Masks.id == AnnotationRejections.mask_id)
+        .join(Images, Images.id == Masks.image_id)
+        .filter(Images.dataset_id == dataset_id,
+                AnnotationRejections.resolved_at.is_(None))
+        .distinct()
+    )
+    return {mask_id for (mask_id,) in rows}
+
+
+def _collect_candidates(dataset_id: int, db: Session,
+                        only_submitted: bool = True) -> list[QueueCandidate]:
+    """Every contour of the dataset's review-ready masks, with hierarchy depth.
+
+    Reviewed contours are always included (queues filter on eligibility later)
+    because depth can only be computed against the full tree — a pending child
+    may hang under an already approved parent.
+    """
+    query = (
+        db.query(
+            Contours.id,
+            Contours.mask_id,
+            Contours.parent_id,
+            Contours.label_id,
+            Contours.confidence_score,
+            Masks.image_id,
+            Contours.reviewed_by.any().label("reviewed"),
+        )
+        .join(Masks, Masks.id == Contours.mask_id)
+        .join(Images, Images.id == Masks.image_id)
+        .filter(Images.dataset_id == dataset_id,
+                Contours.temporary.is_(False))
+    )
+    if only_submitted:
+        query = query.filter(Masks.fully_annotated.is_(True))
+    rows = query.all()
+
+    # A rejected mask is the annotator's again — keep it out of the queue.
+    rejected_masks = _open_rejection_mask_ids(dataset_id, db)
+    rows = [row for row in rows if row.mask_id not in rejected_masks]
+
+    # Depth by walking parent links in memory; one pass per level.
+    parent_of = {row.id: row.parent_id for row in rows}
+    depth_of: dict[int, int] = {}
+
+    def depth(contour_id: int) -> int:
+        if contour_id in depth_of:
+            return depth_of[contour_id]
+        seen = []
+        current = contour_id
+        # Walk up until a known depth or a root; `parent_of.get` treats a parent
+        # outside the candidate set (e.g. filtered mask) as a root.
+        while current is not None and current not in depth_of:
+            seen.append(current)
+            current = parent_of.get(current)
+        base = depth_of[current] if current is not None else -1
+        for offset, node in enumerate(reversed(seen), start=1):
+            depth_of[node] = base + offset
+        return depth_of[contour_id]
+
+    return [
+        QueueCandidate(
+            contour_id=row.id,
+            mask_id=row.mask_id,
+            image_id=row.image_id,
+            label_id=row.label_id,
+            parent_id=row.parent_id,
+            depth=depth(row.id),
+            confidence=row.confidence_score,
+            reviewed=bool(row.reviewed),
+        )
+        for row in rows
+    ]
+
+
+# -- Queue building ----------------------------------------------------------
+
+def _validate_labels(dataset_id: int, label_ids: list[int], db: Session) -> None:
+    known = {
+        label_id for (label_id,) in
+        db.query(Labels.id).filter(Labels.dataset_id == dataset_id,
+                                   Labels.id.in_(label_ids))
+    }
+    unknown = set(label_ids) - known
+    if unknown:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=f"Labels {sorted(unknown)} do not belong to dataset {dataset_id}.",
+        )
+
+
+def build_queue(dataset_id: int, request: ReviewQueueRequest,
+                db: Session) -> ReviewQueueRead:
+    """Build the ordered work list for one review session."""
+    strategy = SORT_STRATEGIES.get(request.sort_strategy)
+    if strategy is None:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=f"Unknown sort strategy '{request.sort_strategy}'. "
+                   f"Available: {sorted(SORT_STRATEGIES)}.",
+        )
+
+    candidates = _collect_candidates(dataset_id, db,
+                                     only_submitted=request.only_submitted)
+    todo = [candidate for candidate in candidates
+            if candidate.eligible(request.include_reviewed)]
+    descending = request.direction is ReviewSortDirection.DESCENDING
+
+    if request.granularity is ReviewGranularity.IMAGES:
+        by_image: dict[int, list[QueueCandidate]] = {}
+        for candidate in candidates:
+            by_image.setdefault(candidate.image_id, []).append(candidate)
+        items = [
+            ReviewQueueImageItem(
+                image_id=image_id,
+                mask_id=group[0].mask_id,
+                pending_instances=sum(
+                    1 for c in group if c.eligible(request.include_reviewed)),
+                total_instances=len(group),
+            )
+            for image_id, group in by_image.items()
+        ]
+        # Only images with something left to look at, most pending work first
+        # (ascending flips that for reviewers who want the quick wins).
+        items = [item for item in items if item.pending_instances > 0]
+        items.sort(key=lambda item: (item.pending_instances, item.image_id),
+                   reverse=not descending)
+        return ReviewQueueRead(granularity=request.granularity,
+                               sort_strategy=request.sort_strategy,
+                               direction=request.direction,
+                               include_reviewed=request.include_reviewed,
+                               total=len(items), images=items)
+
+    if request.granularity is ReviewGranularity.CUSTOM:
+        _validate_labels(dataset_id, request.label_ids, db)
+        wanted = set(request.label_ids)
+        todo = [candidate for candidate in todo if candidate.label_id in wanted]
+
+    scored = [(strategy.score(candidate), candidate) for candidate in todo]
+    # Tiebreakers keep the order stable and group work naturally: same score ->
+    # same image together, then parents before their children.
+    scored.sort(key=lambda pair: (pair[0], pair[1].image_id,
+                                  pair[1].depth, pair[1].contour_id),
+                reverse=descending)
+
+    items = [
+        ReviewQueueInstanceItem(
+            contour_id=candidate.contour_id,
+            mask_id=candidate.mask_id,
+            image_id=candidate.image_id,
+            label_id=candidate.label_id,
+            parent_id=candidate.parent_id,
+            depth=candidate.depth,
+            score=score,
+        )
+        for score, candidate in scored
+    ]
+    return ReviewQueueRead(granularity=request.granularity,
+                           sort_strategy=request.sort_strategy,
+                           direction=request.direction,
+                           include_reviewed=request.include_reviewed,
+                           total=len(items), instances=items)
+
+
+def summarize(dataset_id: int, db: Session) -> ReviewSummary:
+    """The numbers behind "There are x instances to review"."""
+    candidates = _collect_candidates(dataset_id, db, only_submitted=True)
+    pending = [candidate for candidate in candidates if candidate.pending]
+    reviewed = [candidate for candidate in candidates if candidate.reviewed]
+    open_rejections = (
+        db.query(AnnotationRejections)
+        .join(Masks, Masks.id == AnnotationRejections.mask_id)
+        .join(Images, Images.id == Masks.image_id)
+        .filter(Images.dataset_id == dataset_id,
+                AnnotationRejections.resolved_at.is_(None))
+        .count()
+    )
+    return ReviewSummary(
+        pending_instances=len(pending),
+        pending_images=len({candidate.image_id for candidate in pending}),
+        reviewed_instances=len(reviewed),
+        open_rejections=open_rejections,
+        strategies=strategy_options(),
+    )

--- a/tests/test_annotation_queue.py
+++ b/tests/test_annotation_queue.py
@@ -1,0 +1,129 @@
+"""Unit tests for the annotation queue service (`app.services.annotation_queue`).
+
+Covers the ordering strategies, persistence (upsert per dataset+user), strategy
+validation (unknown / unavailable rejected), and the summary. Driven directly
+against the service with a temp SQLite database — the HTTP wiring is the same
+`require()` dependency already covered by the permission-route tests.
+"""
+import pytest
+from fastapi import HTTPException
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from app.database import database
+import app.database.annotation_queues  # noqa: F401
+import app.database.contours  # noqa: F401
+import app.database.dataset_members  # noqa: F401
+import app.database.datasets  # noqa: F401
+import app.database.images  # noqa: F401
+import app.database.labels  # noqa: F401
+import app.database.masks  # noqa: F401
+import app.database.rejections  # noqa: F401
+import app.database.users  # noqa: F401
+from app.database.annotation_queues import AnnotationQueues
+from app.database.datasets import Datasets
+from app.database.images import Images
+from app.database.masks import Masks
+from app.database.users import Users
+from app.services.annotation_queue import (
+    build_and_save_queue,
+    get_saved_queue,
+    strategy_options,
+    summarize,
+)
+
+
+@pytest.fixture
+def ctx(tmp_path):
+    """A dataset with three images (each with a mask) and one annotator."""
+    engine = create_engine(f"sqlite:///{tmp_path / 'queue.db'}")
+    database.metadata.create_all(engine)
+    Session = sessionmaker(bind=engine)
+    db = Session()
+
+    db.add(Users(username="ann", hashed_password="x"))
+    ds = Datasets(name="ds", description="", dataset_type="image",
+                  folder_path="/tmp/ds", created_by="ann")
+    db.add(ds)
+    db.flush()
+
+    image_ids = []
+    for name in ("a.png", "b.png", "c.png"):
+        img = Images(dataset_id=ds.id, file_name=name, file_path=f"/tmp/{name}",
+                     thumbnail_file_path=f"/tmp/t_{name}", width=10, height=10,
+                     color_mode="RGB")
+        db.add(img)
+        db.flush()
+        db.add(Masks(image_id=img.id, fully_annotated=False, file_path=f"/tmp/m_{name}"))
+        image_ids.append(img.id)
+    db.commit()
+
+    yield db, ds, image_ids
+    db.close()
+
+
+def test_as_uploaded_preserves_upload_order(ctx):
+    db, ds, image_ids = ctx
+    queue = build_and_save_queue(ds.id, "ann", "as_uploaded", db)
+    assert queue.image_ids == image_ids
+    assert queue.total == len(image_ids)
+    assert queue.strategy == "as_uploaded"
+
+
+def test_random_is_a_permutation(ctx):
+    db, ds, image_ids = ctx
+    queue = build_and_save_queue(ds.id, "ann", "random", db)
+    assert sorted(queue.image_ids) == sorted(image_ids)
+
+
+def test_build_persists_and_upserts(ctx):
+    db, ds, image_ids = ctx
+    assert get_saved_queue(ds.id, "ann", db) is None
+
+    build_and_save_queue(ds.id, "ann", "as_uploaded", db)
+    saved = get_saved_queue(ds.id, "ann", db)
+    assert saved is not None
+    assert saved.strategy == "as_uploaded"
+    assert saved.image_ids == image_ids
+
+    # Rebuilding with another strategy overwrites the single row, not appends.
+    build_and_save_queue(ds.id, "ann", "random", db)
+    assert db.query(AnnotationQueues).count() == 1
+    assert get_saved_queue(ds.id, "ann", db).strategy == "random"
+
+
+def test_unavailable_strategy_is_rejected(ctx):
+    db, ds, _ = ctx
+    with pytest.raises(HTTPException) as exc:
+        build_and_save_queue(ds.id, "ann", "diversity", db)
+    assert exc.value.status_code == 400
+    # Nothing persisted for a rejected build.
+    assert db.query(AnnotationQueues).count() == 0
+
+
+def test_unknown_strategy_is_rejected(ctx):
+    db, ds, _ = ctx
+    with pytest.raises(HTTPException) as exc:
+        build_and_save_queue(ds.id, "ann", "nope", db)
+    assert exc.value.status_code == 400
+
+
+def test_summary_reports_total_and_saved_state(ctx):
+    db, ds, image_ids = ctx
+    before = summarize(ds.id, "ann", db)
+    assert before.total == len(image_ids)
+    assert before.has_saved_queue is False
+    assert before.saved_strategy is None
+    assert any(s.key == "as_uploaded" for s in before.strategies)
+
+    build_and_save_queue(ds.id, "ann", "as_uploaded", db)
+    after = summarize(ds.id, "ann", db)
+    assert after.has_saved_queue is True
+    assert after.saved_strategy == "as_uploaded"
+
+
+def test_diversity_option_is_a_placeholder():
+    options = {option.key: option for option in strategy_options()}
+    assert options["as_uploaded"].available is True
+    assert options["random"].available is True
+    assert options["diversity"].available is False

--- a/tests/test_correction_queue.py
+++ b/tests/test_correction_queue.py
@@ -1,0 +1,300 @@
+"""Unit tests for the correction queue builder (`app.services.correction_queue`)
+and the resolution flow on the reviews router.
+
+Covers which rejections qualify (open only), oldest/newest ordering with image
+grouping, the reason filter, mask-level (contour-less) items carrying the mask's
+image id, the summary counts, and that resolving with a resolution kind persists
+it and is idempotent. Driven directly against the service with a temp SQLite
+database, same shape as `test_review_queue.py`.
+"""
+from datetime import datetime, timedelta, timezone
+
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from app.database import database
+import app.database.contours  # noqa: F401
+import app.database.dataset_members  # noqa: F401
+import app.database.datasets  # noqa: F401
+import app.database.images  # noqa: F401
+import app.database.labels  # noqa: F401
+import app.database.masks  # noqa: F401
+import app.database.rejections  # noqa: F401
+import app.database.users  # noqa: F401
+from app.database.contours import Contours
+from app.database.datasets import Datasets
+from app.database.images import Images
+from app.database.labels import Labels
+from app.database.masks import Masks
+from app.database.rejections import AnnotationRejections
+from app.database.users import Users
+from app.schemas.review import (
+    CorrectionQueueRequest,
+    CorrectionSortOrder,
+    RejectionReason,
+)
+from app.services.correction_queue import build_queue, summarize
+
+
+def _contour(mask_id, label_id=None, parent_id=None):
+    return Contours(mask_id=mask_id, parent_id=parent_id, label_id=label_id,
+                    added_by="manual", author_username="ann",
+                    confidence_score=1.0, area=1.0, perimeter=1.0,
+                    circularity=1.0, diameter=1.0, x=[0.1, 0.2], y=[0.1, 0.2])
+
+
+def _t(minutes):
+    """A deterministic timestamp, `minutes` after a fixed base."""
+    return datetime(2026, 1, 1, tzinfo=timezone.utc) + timedelta(minutes=minutes)
+
+
+@pytest.fixture
+def ctx(tmp_path):
+    """Two images, each with a mask. Three open rejections (a contour-level one on
+    image 1, a mask-level one on image 2, a second contour-level one on image 1)
+    plus one already-resolved rejection that must never appear."""
+    engine = create_engine(f"sqlite:///{tmp_path / 'correction.db'}")
+    database.metadata.create_all(engine)
+    db = sessionmaker(bind=engine)()
+
+    db.add_all([Users(username="ann", hashed_password="x"),
+                Users(username="rev", hashed_password="x")])
+    ds = Datasets(name="ds", description="", dataset_type="image",
+                  folder_path="/tmp/ds", created_by="ann")
+    db.add(ds)
+    db.flush()
+
+    cell = Labels(dataset_id=ds.id, name="cell", value=1)
+    db.add(cell)
+    db.flush()
+
+    def image_with_mask(name):
+        img = Images(dataset_id=ds.id, file_name=name, file_path=f"/tmp/{name}",
+                     thumbnail_file_path=f"/tmp/t_{name}", width=10, height=10,
+                     color_mode="RGB")
+        db.add(img)
+        db.flush()
+        mask = Masks(image_id=img.id, fully_annotated=False,
+                     file_path=f"/tmp/m_{name}")
+        db.add(mask)
+        db.flush()
+        return img, mask
+
+    img1, mask1 = image_with_mask("a.png")
+    img2, mask2 = image_with_mask("b.png")
+    con1 = _contour(mask1.id, label_id=cell.id)
+    con2 = _contour(mask1.id, label_id=cell.id)
+    db.add_all([con1, con2])
+    db.flush()
+
+    # Open: contour-level bad_outline on image 1 (oldest), mask-level
+    # missing_objects on image 2 (middle), contour-level wrong_label on image 1
+    # (newest). Resolved: an old one on image 1 that must be filtered out.
+    rej_outline = AnnotationRejections(
+        mask_id=mask1.id, contour_id=con1.id, reason=RejectionReason.BAD_OUTLINE.value,
+        note="fix the edge", created_by="rev", created_at=_t(0))
+    rej_missing = AnnotationRejections(
+        mask_id=mask2.id, contour_id=None, reason=RejectionReason.MISSING_OBJECTS.value,
+        created_by="rev", created_at=_t(10))
+    rej_label = AnnotationRejections(
+        mask_id=mask1.id, contour_id=con2.id, reason=RejectionReason.WRONG_LABEL.value,
+        created_by="rev", created_at=_t(20))
+    rej_done = AnnotationRejections(
+        mask_id=mask1.id, contour_id=con1.id, reason=RejectionReason.OTHER.value,
+        note="already handled", created_by="rev", created_at=_t(-10),
+        resolved_at=_t(-5), resolved_by="ann")
+    db.add_all([rej_outline, rej_missing, rej_label, rej_done])
+    db.commit()
+
+    yield {
+        "db": db, "dataset_id": ds.id,
+        "masks": {"one": mask1.id, "two": mask2.id},
+        "images": {"one": img1.id, "two": img2.id},
+        "contours": {"one": con1.id, "two": con2.id},
+        "rejections": {"outline": rej_outline.id, "missing": rej_missing.id,
+                       "label": rej_label.id, "done": rej_done.id},
+    }
+    db.close()
+
+
+def test_summary_counts_open_rejections_only(ctx):
+    summary = summarize(ctx["dataset_id"], ctx["db"])
+    assert summary.open_rejections == 3           # resolved one excluded
+    assert summary.affected_instances == 2        # con1, con2 (mask-level not counted)
+    assert summary.affected_images == 2
+
+
+def test_queue_lists_open_not_resolved(ctx):
+    queue = build_queue(ctx["dataset_id"],
+                        CorrectionQueueRequest(order=CorrectionSortOrder.OLDEST),
+                        ctx["db"])
+    ids = {item.rejection_id for item in queue.items}
+    assert ctx["rejections"]["done"] not in ids
+    assert queue.total == 3
+
+
+def test_oldest_order_groups_image_one_first(ctx):
+    """Oldest-first: image 1 (leads at t=0) before image 2 (t=10), and image 1's
+    two items stay together in age order."""
+    queue = build_queue(ctx["dataset_id"],
+                        CorrectionQueueRequest(order=CorrectionSortOrder.OLDEST),
+                        ctx["db"])
+    r = ctx["rejections"]
+    assert [item.rejection_id for item in queue.items] == [r["outline"], r["label"], r["missing"]]
+
+
+def test_newest_order_puts_image_one_last(ctx):
+    """Newest-first: image 1 now leads with its newest item (t=20), so it comes
+    before image 2 (t=10), and image 1's items are newest-first within the group."""
+    queue = build_queue(ctx["dataset_id"],
+                        CorrectionQueueRequest(order=CorrectionSortOrder.NEWEST),
+                        ctx["db"])
+    r = ctx["rejections"]
+    assert [item.rejection_id for item in queue.items] == [r["label"], r["outline"], r["missing"]]
+
+
+def test_reason_filter(ctx):
+    queue = build_queue(ctx["dataset_id"], CorrectionQueueRequest(
+        reasons=[RejectionReason.BAD_OUTLINE]), ctx["db"])
+    assert [item.rejection_id for item in queue.items] == [ctx["rejections"]["outline"]]
+    assert queue.items[0].reason_label == "Outline is inaccurate"
+    assert queue.items[0].note == "fix the edge"
+
+
+def test_mask_level_item_carries_image_id_and_null_contour(ctx):
+    queue = build_queue(ctx["dataset_id"], CorrectionQueueRequest(
+        reasons=[RejectionReason.MISSING_OBJECTS]), ctx["db"])
+    item = queue.items[0]
+    assert item.contour_id is None
+    assert item.image_id == ctx["images"]["two"]
+    assert item.mask_id == ctx["masks"]["two"]
+
+
+def _reviews_client(ctx, username):
+    from fastapi import Depends, FastAPI
+    from fastapi.testclient import TestClient
+
+    from app.database import get_session
+    from app.routes.general.reviews import router as review_router
+    from app.schemas.auth_user import AuthenticatedUser
+    from app.services.auth import get_current_user
+
+    db = ctx["db"]
+    app = FastAPI()
+    app.include_router(review_router)
+
+    def _session_override():
+        yield db
+
+    def _user_override(session=Depends(_session_override)):
+        row = session.query(Users).filter_by(username=username).one()
+        return AuthenticatedUser.from_query(row)
+
+    app.dependency_overrides[get_session] = _session_override
+    app.dependency_overrides[get_current_user] = _user_override
+    return TestClient(app)
+
+
+def _grant(ctx, username, role):
+    from app.database.dataset_members import DatasetMembers
+
+    ctx["db"].add(DatasetMembers(dataset_id=ctx["dataset_id"], username=username,
+                                 role=role, extra_permissions=[],
+                                 denied_permissions=[]))
+    ctx["db"].commit()
+
+
+def test_resolve_records_resolution_and_is_idempotent(ctx):
+    """Resolving with a resolution persists it; a second resolve never overwrites
+    the first verdict."""
+    from app.schemas.permissions import DatasetRole
+
+    _grant(ctx, "ann", DatasetRole.ANNOTATOR.value)
+    client = _reviews_client(ctx, "ann")
+    rejection_id = ctx["rejections"]["outline"]
+
+    body = client.patch(f"/reviews/rejections/{rejection_id}/resolve",
+                        json={"resolution": "wont_fix"}).json()
+    assert body["success"] is True
+    assert body["rejection"]["resolution"] == "wont_fix"
+    assert body["rejection"]["resolved_at"] is not None
+
+    row = ctx["db"].query(AnnotationRejections).filter_by(id=rejection_id).one()
+    assert row.resolution == "wont_fix"
+
+    # A resolve without a body must not clobber the recorded verdict.
+    again = client.patch(f"/reviews/rejections/{rejection_id}/resolve").json()
+    assert again["rejection"]["resolution"] == "wont_fix"
+
+
+def test_correction_summary_endpoint(ctx):
+    from app.schemas.permissions import DatasetRole
+
+    _grant(ctx, "ann", DatasetRole.ANNOTATOR.value)
+    body = _reviews_client(ctx, "ann").get(
+        f"/reviews/datasets/{ctx['dataset_id']}/correction-summary").json()
+    assert body["success"] is True
+    assert body["summary"]["open_rejections"] == 3
+
+
+def test_replace_contour_preserves_open_rejection(tmp_path):
+    """Refining an outline is a `replace_contour` — delete + re-insert under the
+    SAME id. The ON DELETE CASCADE on annotation_rejections.contour_id would wipe
+    the open rejection (and 404 the correction queue's "Mark as done" that follows);
+    the replace must instead carry the rejection across, keeping its id."""
+    import asyncio
+
+    from iquana_toolbox.schemas.database.contours import Contour
+
+    from app.database.contours import save_contour_tree
+    from app.services.database_access.contours import replace_contour
+
+    engine = create_engine(f"sqlite:///{tmp_path / 'replace.db'}")
+    database.metadata.create_all(engine)
+    db = sessionmaker(bind=engine)()
+
+    db.add_all([Users(username="ann", hashed_password="x"),
+                Users(username="rev", hashed_password="x")])
+    ds = Datasets(name="ds", description="", dataset_type="image",
+                  folder_path="/tmp/ds", created_by="ann")
+    db.add(ds)
+    db.flush()
+    label = Labels(dataset_id=ds.id, name="cell", value=1)
+    db.add(label)
+    db.flush()
+    img = Images(dataset_id=ds.id, file_name="a.png", file_path="/tmp/a.png",
+                 thumbnail_file_path="/tmp/t.png", width=100, height=100,
+                 color_mode="RGB", scale_x=1.0, scale_y=1.0, unit="px")
+    db.add(img)
+    db.flush()
+    mask = Masks(image_id=img.id, fully_annotated=True, file_path="/tmp/m.png")
+    db.add(mask)
+    db.flush()
+
+    contour = save_contour_tree(
+        db,
+        Contour(x=[0.1, 0.5, 0.5, 0.1], y=[0.1, 0.1, 0.5, 0.5],
+                label_id=label.id, added_by="ann"),
+        mask.id,
+    )
+    db.commit()
+    contour_id = contour.id
+
+    rejection = AnnotationRejections(mask_id=mask.id, contour_id=contour_id,
+                                     reason=RejectionReason.BAD_OUTLINE.value,
+                                     created_by="rev")
+    db.add(rejection)
+    db.commit()
+    rejection_id = rejection.id
+
+    # The annotator redraws the outline → replace_contour under the same id.
+    new_outline = Contour(x=[0.2, 0.6, 0.6, 0.2], y=[0.2, 0.2, 0.6, 0.6],
+                          label_id=label.id, added_by="ann")
+    assert asyncio.run(replace_contour(contour_id, new_outline, db)) is True
+
+    survived = db.query(AnnotationRejections).filter_by(id=rejection_id).one_or_none()
+    assert survived is not None, "the open rejection was cascade-deleted by the refine"
+    assert survived.contour_id == contour_id  # re-pointed to the reused contour id
+    assert db.query(Contours).filter_by(id=contour_id).one_or_none() is not None
+    db.close()

--- a/tests/test_image_backfill.py
+++ b/tests/test_image_backfill.py
@@ -1,0 +1,92 @@
+"""The image-dimension backfill: repairs rows hit by the thumbnail-mutation
+ingest bug and re-derives the geometry metrics computed from the wrong size."""
+import asyncio
+
+import pytest
+from PIL import Image as PILImage
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from app.database import database
+import app.database.contours  # noqa: F401
+import app.database.dataset_members  # noqa: F401
+import app.database.datasets  # noqa: F401
+import app.database.images  # noqa: F401
+import app.database.labels  # noqa: F401
+import app.database.masks  # noqa: F401
+import app.database.rejections  # noqa: F401
+import app.database.users  # noqa: F401
+from app.database.contour_metrics import ContourMetrics
+from app.database.contours import Contours
+from app.database.datasets import Datasets
+from app.database.images import Images
+from app.database.masks import Masks
+from app.database.users import Users
+from app.services.database_access.images import backfill_image_dimensions
+
+
+@pytest.fixture
+def ctx(tmp_path):
+    """One image whose DB row carries thumbnail dimensions while the file on
+    disk is the 400x300 original, plus a contour with metrics derived from the
+    wrong size."""
+    engine = create_engine(f"sqlite:///{tmp_path / 'backfill.db'}")
+    database.metadata.create_all(engine)
+    db = sessionmaker(bind=engine)()
+
+    db.add(Users(username="ann", hashed_password="x"))
+    ds = Datasets(name="ds", description="", dataset_type="image",
+                  folder_path=str(tmp_path), created_by="ann")
+    db.add(ds)
+    db.flush()
+
+    file_path = tmp_path / "a.png"
+    PILImage.new("RGB", (400, 300), (10, 20, 30)).save(file_path)
+
+    img = Images(dataset_id=ds.id, file_name="a.png", file_path=str(file_path),
+                 thumbnail_file_path=str(tmp_path / "t.png"),
+                 # The bug: thumbnail dimensions in the row, original on disk.
+                 width=200, height=150, color_mode="RGB")
+    db.add(img)
+    db.flush()
+    mask = Masks(image_id=img.id, fully_annotated=True, file_path="/tmp/m.png")
+    db.add(mask)
+    db.flush()
+    contour = Contours(mask_id=mask.id, added_by="manual", author_username="ann",
+                       confidence_score=1.0, area=1.0, perimeter=1.0,
+                       circularity=1.0, diameter=1.0,
+                       x=[0.1, 0.5, 0.5, 0.1], y=[0.1, 0.1, 0.5, 0.5])
+    db.add(contour)
+    db.commit()
+
+    yield {"db": db, "dataset_id": ds.id, "image_id": img.id,
+           "contour_id": contour.id}
+    db.close()
+
+
+def test_backfill_fixes_dimensions_and_recomputes_geometry(ctx):
+    db = ctx["db"]
+    result = asyncio.run(backfill_image_dimensions(db, dataset_id=ctx["dataset_id"]))
+    assert result["corrected"] == [ctx["image_id"]]
+    assert result["missing"] == []
+    assert result["recomputed_contours"] == 1
+
+    image = db.query(Images).filter_by(id=ctx["image_id"]).one()
+    assert (image.width, image.height) == (400, 300)
+
+    # 0.4 x 0.4 of a 400x300 image = a 160x120 px rectangle.
+    contour = db.query(Contours).filter_by(id=ctx["contour_id"]).one()
+    assert contour.area == pytest.approx(160 * 120, rel=0.01)
+
+    area_row = (db.query(ContourMetrics)
+                .filter_by(contour_id=ctx["contour_id"], metric_key="area").one())
+    assert area_row.value == pytest.approx(160 * 120, rel=0.01)
+    assert area_row.stale is False
+
+
+def test_backfill_is_idempotent(ctx):
+    db = ctx["db"]
+    asyncio.run(backfill_image_dimensions(db, dataset_id=ctx["dataset_id"]))
+    again = asyncio.run(backfill_image_dimensions(db, dataset_id=ctx["dataset_id"]))
+    assert again["corrected"] == []
+    assert again["recomputed_contours"] == 0

--- a/tests/test_review_queue.py
+++ b/tests/test_review_queue.py
@@ -1,0 +1,311 @@
+"""Unit tests for the review queue builder (`app.services.review_queue`).
+
+Covers candidate collection (which masks and contours qualify), hierarchy depth
+computation, the sort strategies, image-level grouping, the custom label filter
+and the summary counts. Driven directly against the service with a temp SQLite
+database — the HTTP wiring is the same `require()` dependency already covered by
+`test_permission_routes.py`.
+"""
+import pytest
+from fastapi import HTTPException
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from app.database import database
+import app.database.contours  # noqa: F401
+import app.database.dataset_members  # noqa: F401
+import app.database.datasets  # noqa: F401
+import app.database.images  # noqa: F401
+import app.database.labels  # noqa: F401
+import app.database.masks  # noqa: F401
+import app.database.rejections  # noqa: F401
+import app.database.users  # noqa: F401
+from app.database.contours import Contours
+from app.database.datasets import Datasets
+from app.database.images import Images
+from app.database.labels import Labels
+from app.database.masks import Masks
+from app.database.rejections import AnnotationRejections
+from app.database.users import Users
+from app.schemas.review import (
+    ReviewGranularity,
+    ReviewQueueRequest,
+    ReviewSortDirection,
+)
+from app.services.review_queue import SORT_STRATEGIES, build_queue, summarize
+
+
+def _contour(mask_id, label_id=None, parent_id=None, author="ann", confidence=1.0):
+    return Contours(mask_id=mask_id, parent_id=parent_id, label_id=label_id,
+                    added_by="manual", author_username=author,
+                    confidence_score=confidence, area=1.0, perimeter=1.0,
+                    circularity=1.0, diameter=1.0, x=[0.1, 0.2], y=[0.1, 0.2])
+
+
+@pytest.fixture
+def ctx(tmp_path):
+    """A dataset with one reviewable mask (a 3-deep hierarchy plus one already
+    approved root), one unsubmitted mask and one rejected mask."""
+    engine = create_engine(f"sqlite:///{tmp_path / 'queue.db'}")
+    database.metadata.create_all(engine)
+    Session = sessionmaker(bind=engine)
+    db = Session()
+
+    db.add_all([Users(username="ann", hashed_password="x"),
+                Users(username="rev", hashed_password="x")])
+    ds = Datasets(name="ds", description="", dataset_type="image",
+                  folder_path="/tmp/ds", created_by="ann")
+    db.add(ds)
+    db.flush()
+
+    cell = Labels(dataset_id=ds.id, name="cell", value=1)
+    core = Labels(dataset_id=ds.id, name="core", value=2)
+    db.add_all([cell, core])
+    db.flush()
+
+    def image_with_mask(name, fully_annotated):
+        img = Images(dataset_id=ds.id, file_name=name, file_path=f"/tmp/{name}",
+                     thumbnail_file_path=f"/tmp/t_{name}", width=10, height=10,
+                     color_mode="RGB")
+        db.add(img)
+        db.flush()
+        mask = Masks(image_id=img.id, fully_annotated=fully_annotated,
+                     file_path=f"/tmp/m_{name}")
+        db.add(mask)
+        db.flush()
+        return img, mask
+
+    # Submitted mask: root_a > child_b > grandchild_c, plus approved root_d.
+    img1, mask1 = image_with_mask("a.png", fully_annotated=True)
+    root_a = _contour(mask1.id, label_id=cell.id, confidence=0.4)
+    db.add(root_a)
+    db.flush()
+    child_b = _contour(mask1.id, label_id=core.id, parent_id=root_a.id, confidence=0.9)
+    db.add(child_b)
+    db.flush()
+    grandchild_c = _contour(mask1.id, label_id=core.id, parent_id=child_b.id)
+    root_d = _contour(mask1.id, label_id=cell.id)
+    db.add_all([grandchild_c, root_d])
+    db.flush()
+    root_d.reviewed_by.append(db.query(Users).filter_by(username="rev").one())
+
+    # Still in progress: excluded unless only_submitted=False.
+    img2, mask2 = image_with_mask("b.png", fully_annotated=False)
+    in_progress = _contour(mask2.id, label_id=cell.id)
+    db.add(in_progress)
+
+    # Submitted but sent back: an open rejection keeps it out of every queue.
+    img3, mask3 = image_with_mask("c.png", fully_annotated=True)
+    db.add(_contour(mask3.id, label_id=cell.id))
+    db.add(AnnotationRejections(mask_id=mask3.id, reason="bad_outline",
+                                created_by="rev"))
+    db.commit()
+
+    yield {
+        "db": db, "dataset_id": ds.id,
+        "labels": {"cell": cell.id, "core": core.id},
+        "contours": {"a": root_a.id, "b": child_b.id, "c": grandchild_c.id,
+                     "d": root_d.id, "in_progress": in_progress.id},
+        "images": {"submitted": img1.id, "in_progress": img2.id, "rejected": img3.id},
+    }
+    db.close()
+
+
+def test_summary_counts_only_submitted_unreviewed_work(ctx):
+    summary = summarize(ctx["dataset_id"], ctx["db"])
+    # a, b, c pending; d approved, in-progress mask not submitted, rejected mask out.
+    assert summary.pending_instances == 3
+    assert summary.pending_images == 1
+    assert summary.reviewed_instances == 1
+    assert summary.open_rejections == 1
+    assert {option.key for option in summary.strategies} >= {"hierarchy"}
+
+
+def test_hierarchy_queue_orders_roots_first(ctx):
+    queue = build_queue(ctx["dataset_id"], ReviewQueueRequest(
+        granularity=ReviewGranularity.HIERARCHY), ctx["db"])
+    ids = [item.contour_id for item in queue.instances]
+    c = ctx["contours"]
+    assert ids == [c["a"], c["b"], c["c"]]
+    assert [item.depth for item in queue.instances] == [0, 1, 2]
+    assert queue.total == 3
+
+
+def test_include_reviewed_requeues_approved_work_own_included(ctx):
+    """A solo reviewer must be able to re-sweep everything, their own approvals
+    included — root_d (already approved by rev) comes back for everyone."""
+    c = ctx["contours"]
+    queue = build_queue(ctx["dataset_id"], ReviewQueueRequest(
+        granularity=ReviewGranularity.HIERARCHY, include_reviewed=True), ctx["db"])
+    assert queue.include_reviewed is True
+    assert [item.contour_id for item in queue.instances] == [c["a"], c["d"], c["b"], c["c"]]
+
+
+def test_descending_reverses_the_order(ctx):
+    queue = build_queue(ctx["dataset_id"], ReviewQueueRequest(
+        granularity=ReviewGranularity.HIERARCHY,
+        direction=ReviewSortDirection.DESCENDING), ctx["db"])
+    c = ctx["contours"]
+    assert [item.contour_id for item in queue.instances] == [c["c"], c["b"], c["a"]]
+
+
+def test_only_submitted_false_sweeps_in_progress_work(ctx):
+    queue = build_queue(ctx["dataset_id"], ReviewQueueRequest(
+        granularity=ReviewGranularity.HIERARCHY, only_submitted=False), ctx["db"])
+    ids = {item.contour_id for item in queue.instances}
+    assert ctx["contours"]["in_progress"] in ids
+    assert queue.total == 4
+
+
+def test_image_queue_groups_and_counts(ctx):
+    queue = build_queue(ctx["dataset_id"], ReviewQueueRequest(
+        granularity=ReviewGranularity.IMAGES), ctx["db"])
+    assert queue.total == 1
+    item = queue.images[0]
+    assert item.image_id == ctx["images"]["submitted"]
+    assert item.pending_instances == 3
+    assert item.total_instances == 4
+
+
+def test_image_queue_counts_reviewed_work_when_included(ctx):
+    queue = build_queue(ctx["dataset_id"], ReviewQueueRequest(
+        granularity=ReviewGranularity.IMAGES, include_reviewed=True), ctx["db"])
+    assert queue.images[0].pending_instances == 4
+
+
+def test_custom_queue_filters_by_label(ctx):
+    queue = build_queue(ctx["dataset_id"], ReviewQueueRequest(
+        granularity=ReviewGranularity.CUSTOM,
+        label_ids=[ctx["labels"]["core"]]), ctx["db"])
+    c = ctx["contours"]
+    assert [item.contour_id for item in queue.instances] == [c["b"], c["c"]]
+
+
+def test_custom_queue_rejects_foreign_labels(ctx):
+    with pytest.raises(HTTPException) as exc:
+        build_queue(ctx["dataset_id"], ReviewQueueRequest(
+            granularity=ReviewGranularity.CUSTOM, label_ids=[999]), ctx["db"])
+    assert exc.value.status_code == 400
+
+
+def test_unknown_strategy_is_rejected(ctx):
+    with pytest.raises(HTTPException) as exc:
+        build_queue(ctx["dataset_id"], ReviewQueueRequest(
+            granularity=ReviewGranularity.HIERARCHY,
+            sort_strategy="does-not-exist"), ctx["db"])
+    assert exc.value.status_code == 400
+
+
+def test_uncertainty_strategy_orders_least_confident_first(ctx):
+    assert "uncertainty" in SORT_STRATEGIES
+    queue = build_queue(ctx["dataset_id"], ReviewQueueRequest(
+        granularity=ReviewGranularity.HIERARCHY,
+        sort_strategy="uncertainty"), ctx["db"])
+    scores = [item.score for item in queue.instances]
+    assert scores == sorted(scores)
+    # root_a (0.4) is the least confident pending contour.
+    assert queue.instances[0].contour_id == ctx["contours"]["a"]
+
+
+def test_rejecting_a_contour_withdraws_own_approval_only(ctx):
+    """Rejecting an instance you approved earlier overwrites your verdict; a
+    co-reviewer's approval of the same contour is untouched."""
+    import asyncio
+
+    from app.schemas.review import RejectionCreate, RejectionReason
+    from app.services.database_access import rejections as rejections_db
+
+    db = ctx["db"]
+    d = db.query(Contours).filter_by(id=ctx["contours"]["d"]).one()
+    db.add(Users(username="rev2", hashed_password="x"))
+    db.flush()
+    d.reviewed_by.append(db.query(Users).filter_by(username="rev2").one())
+    db.commit()
+
+    asyncio.run(rejections_db.reject(
+        d.mask_id,
+        RejectionCreate(reason=RejectionReason.BAD_OUTLINE, contour_id=d.id),
+        username="rev", db=db,
+    ))
+    assert {u.username for u in d.reviewed_by} == {"rev2"}
+
+
+def _review_client(ctx, username):
+    """A client for the real reviews router, authenticated as `username`."""
+    from fastapi import Depends, FastAPI
+    from fastapi.testclient import TestClient
+
+    from app.database import get_session
+    from app.routes.general.reviews import router as review_router
+    from app.schemas.auth_user import AuthenticatedUser
+    from app.services.auth import get_current_user
+
+    db = ctx["db"]
+    app = FastAPI()
+    app.include_router(review_router)
+
+    def _session_override():
+        yield db
+
+    def _user_override(session=Depends(_session_override)):
+        row = session.query(Users).filter_by(username=username).one()
+        return AuthenticatedUser.from_query(row)
+
+    app.dependency_overrides[get_session] = _session_override
+    app.dependency_overrides[get_current_user] = _user_override
+    return TestClient(app)
+
+
+def _grant(ctx, username, role):
+    from app.database.dataset_members import DatasetMembers
+
+    ctx["db"].add(DatasetMembers(dataset_id=ctx["dataset_id"], username=username,
+                                 role=role, extra_permissions=[],
+                                 denied_permissions=[]))
+
+
+def test_bulk_approve_respects_separation_of_duties(ctx):
+    """The image-level Accept approves everything pending except the caller's own
+    work on datasets that require independent review."""
+    from app.schemas.permissions import DatasetRole
+
+    db = ctx["db"]
+    dataset = db.query(Datasets).filter_by(id=ctx["dataset_id"]).one()
+    dataset.require_independent_review = True
+    _grant(ctx, "rev", DatasetRole.REVIEWER.value)
+    # child_b now belongs to the reviewer, so approving it themselves must be skipped.
+    child = db.query(Contours).filter_by(id=ctx["contours"]["b"]).one()
+    child.author_username = "rev"
+    db.commit()
+
+    mask_id = db.query(Contours.mask_id).filter_by(id=ctx["contours"]["a"]).scalar()
+    response = _review_client(ctx, "rev").post(f"/reviews/masks/{mask_id}/approve")
+    assert response.status_code == 200
+    body = response.json()
+    assert set(body["approved"]) == {ctx["contours"]["a"], ctx["contours"]["c"]}
+    assert body["skipped"] == [ctx["contours"]["b"]]
+
+
+def test_bulk_approve_can_stack_a_second_opinion(ctx):
+    """With include_reviewed, a fresh reviewer's Accept also covers contours that
+    already carry someone else's approval — approvals add up, never replace."""
+    from app.schemas.permissions import DatasetRole
+
+    db = ctx["db"]
+    db.add(Users(username="rev2", hashed_password="x"))
+    _grant(ctx, "rev2", DatasetRole.REVIEWER.value)
+    db.commit()
+
+    mask_id = db.query(Contours.mask_id).filter_by(id=ctx["contours"]["a"]).scalar()
+    client = _review_client(ctx, "rev2")
+
+    # Without the flag, root_d (already approved by rev) stays untouched.
+    body = client.post(f"/reviews/masks/{mask_id}/approve").json()
+    assert ctx["contours"]["d"] not in body["approved"]
+
+    # With it, rev2's approval lands on top of rev's.
+    body = client.post(f"/reviews/masks/{mask_id}/approve?include_reviewed=true").json()
+    assert ctx["contours"]["d"] in body["approved"]
+    reviewers = {user.username for user in
+                 db.query(Contours).filter_by(id=ctx["contours"]["d"]).one().reviewed_by}
+    assert reviewers == {"rev", "rev2"}


### PR DESCRIPTION
Added review and correct cards. 

Review:
- Create a review queue to look at images or instances
- Opens up a new viewer showing either one imager or one instance with options to accept or send back with a reason for rejection

Correct:
- Collects the rejections
- Create a correct queue with filters and recency
- Opens up the annotation page, with the wrong instance being pre-selected in refinement mode
- Users can then refine and select "done" or say "wont fix"

Additional changes:
- tidied up cards in dataset management
- added new context menu point in annotation canvas. User can now refine the mask via slicing.