### PR TITLE
Implement undo/redo functionality for annotation workspace

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -7,6 +7,7 @@ from fastapi.middleware.cors import CORSMiddleware
 
 from app.database import init_db
 from app.routes.general.admin import router as admin_router
+from app.routes.general.annotation_history import router as annotation_history_router
 from app.routes.general.annotation_queue import router as annotation_queue_router
 from app.routes.general.auth import router as auth_router
 from app.routes.general.calibration import router as calibration_router
@@ -89,6 +90,7 @@ def create_app():
     app.include_router(image_annotation_session_router)
     app.include_router(mask_router)
     app.include_router(contour_router)
+    app.include_router(annotation_history_router)
     app.include_router(label_router)
     app.include_router(scale_router)
     # Generalises the /scale router above to every calibration kind; /scale stays

--- a/app/database/__init__.py
+++ b/app/database/__init__.py
@@ -54,6 +54,7 @@ def _import_models():
     mapper and the table missing from a fresh database.
     """
     from app.database import (  # noqa: F401  (imported for their side effects)
+        annotation_actions,
         annotation_queues,
         contour_metrics,
         contours,

--- a/app/database/annotation_actions.py
+++ b/app/database/annotation_actions.py
@@ -1,0 +1,81 @@
+"""The per-annotator action history that backs undo/redo in the workspace.
+
+One row is one undoable step. The stack is implicit: rows for a given
+``(mask_id, username)`` ordered by ``id``, split by the ``undone`` flag --
+``undone=False`` rows are the undo stack (newest first), ``undone=True`` rows are
+the redo stack. Recording a new action discards the ``undone=True`` rows, which is
+the usual "a new edit kills the redo branch" rule.
+
+Why a table rather than client state: undoing a delete has to bring back the
+contour the user actually deleted -- same id, same children, same label, same
+approvals -- and only the server can do that. A client-side stack could at best
+re-create a lookalike under a fresh id, orphaning its children and any review
+already recorded against it.
+
+The history is deliberately narrow. It covers what an annotator does object by
+object (add, delete, relabel); it does not cover geometry replacement
+(``replace_contour``) or instance segmentation's wipe-and-replace, whose inverses
+are not a single contour and would be misleading behind a one-step Ctrl+Z.
+"""
+from datetime import datetime, timezone
+
+from sqlalchemy import Boolean, Column, DateTime, ForeignKey, Index, Integer, JSON, String
+
+from app.database import database
+
+#: How many steps of history are kept per annotator per image. Older rows are
+#: pruned as new ones arrive. Undo here is a mistake-recovery tool ("I deleted the
+#: wrong object"), not a version-control system, and an unbounded log would keep a
+#: full geometry snapshot of every contour ever deleted from the image.
+MAX_HISTORY_ENTRIES = 10
+
+
+class ActionType:
+    """The kinds of step the history can invert.
+
+    ``CREATE`` and ``DELETE`` are exact inverses of each other and share one
+    payload shape, so a single snapshot serves both directions.
+    """
+
+    CREATE = "create"
+    DELETE = "delete"
+    LABEL = "label"
+
+
+def _utcnow() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+class AnnotationActions(database):
+    """One undoable step taken by one annotator on one image."""
+
+    __tablename__ = "annotation_actions"
+
+    id = Column(Integer, primary_key=True, autoincrement=True)
+    mask_id = Column(Integer, ForeignKey("masks.id", ondelete="CASCADE"),
+                     nullable=False, index=True)
+    # The stack is per annotator: Ctrl+Z must never revert a colleague's work on
+    # a shared image. FK to users so a deleted account takes its history with it.
+    username = Column(String, ForeignKey("users.username", ondelete="CASCADE"),
+                      nullable=False, index=True)
+    # Rows sharing a group are one step in both directions. Set for fan-out
+    # operations -- a suggestion run that adds thirty instances should cost one
+    # Ctrl+Z, not thirty. NULL for ordinary single-object actions.
+    group_id = Column(String(64), nullable=True, index=True)
+    action_type = Column(String(16), nullable=False)
+    # Everything needed to invert AND re-apply the step, so undo and redo read the
+    # same row. See app.services.database_access.annotation_history for the shapes.
+    payload = Column(JSON, nullable=False)
+    created_at = Column(DateTime, nullable=False, default=_utcnow)
+    #: False => on the undo stack. True => undone, and on the redo stack.
+    undone = Column(Boolean, nullable=False, default=False)
+
+
+# Every read is "the newest (un)done row for this annotator on this image", so
+# index the pair that scopes it; ordering falls out of the primary key.
+Index(
+    "ix_annotation_actions_stack",
+    AnnotationActions.mask_id,
+    AnnotationActions.username,
+    AnnotationActions.undone,
+)

--- a/app/routes/general/annotation_history.py
+++ b/app/routes/general/annotation_history.py
@@ -1,0 +1,90 @@
+"""Undo / redo endpoints for the annotation workspace.
+
+Deliberately REST rather than WebSocket messages. The annotation socket's message
+types are an enum in the shared `iquana_toolbox` package, where UNDO and REDO sit
+commented out; adding them means shipping that package first. These three routes
+need nothing from the socket -- they act on the database and hand back the mask's
+whole contour hierarchy, which is the same payload the socket's OBJECTS message
+carries, so the client refreshes through the code path it already has.
+
+Returning the full hierarchy rather than a delta is the point: after an undo the
+client's object list must match the database exactly, and one refresh path cannot
+drift the way a set of hand-applied inverse deltas would.
+"""
+from logging import getLogger
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from sqlalchemy.orm import Session
+
+from app.database import get_session
+from app.schemas.auth_user import AuthenticatedUser
+from app.schemas.permissions import Permission
+from app.services.database_access import annotation_history as history_db
+from app.services.database_access import masks as masks_db
+from app.services.permissions import require
+
+router = APIRouter(prefix="/annotation-history", tags=["annotation history"])
+logger = getLogger(__name__)
+
+
+def _mask_id_or_404(image_id: int, db: Session) -> int:
+    mask_id = history_db.mask_id_for_image(image_id, db)
+    if mask_id is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND,
+                            detail=f"Image {image_id} has no mask to undo work on.")
+    return mask_id
+
+
+@router.get("/{image_id}")
+async def get_history_status(
+        image_id: int,
+        db: Session = Depends(get_session),
+        user: AuthenticatedUser = Depends(require(Permission.ANNOTATION_EDIT_OWN, "image_id")),
+):
+    """Whether this annotator has anything to undo or redo on this image.
+
+    Backs the enabled state and the tooltip of the toolbar's two buttons, so the
+    user is never offered an undo that would immediately fail.
+    """
+    mask_id = _mask_id_or_404(image_id, db)
+    return {"success": True, **history_db.get_status(mask_id, user.username, db)}
+
+
+async def _apply(image_id: int, db: Session, user: AuthenticatedUser, redo: bool):
+    """Shared body of the two mutating routes."""
+    mask_id = _mask_id_or_404(image_id, db)
+    try:
+        result = (history_db.redo if redo else history_db.undo)(mask_id, user.username, db)
+    except history_db.HistoryError as exc:
+        # A 409 rather than a 400: the request was well formed, the world just moved
+        # on (the object was deleted by someone else, the label is gone).
+        raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail=str(exc))
+
+    _, payload = await masks_db.get_cached_contour_hierarchy_of_mask(mask_id, db)
+    return {
+        "success": True,
+        "message": result["message"],
+        "action_type": result["action_type"],
+        "contours": payload,
+        **history_db.get_status(mask_id, user.username, db),
+    }
+
+
+@router.post("/{image_id}/undo")
+async def undo_last_action(
+        image_id: int,
+        db: Session = Depends(get_session),
+        user: AuthenticatedUser = Depends(require(Permission.ANNOTATION_EDIT_OWN, "image_id")),
+):
+    """Revert this annotator's most recent action on this image."""
+    return await _apply(image_id, db, user, redo=False)
+
+
+@router.post("/{image_id}/redo")
+async def redo_last_action(
+        image_id: int,
+        db: Session = Depends(get_session),
+        user: AuthenticatedUser = Depends(require(Permission.ANNOTATION_EDIT_OWN, "image_id")),
+):
+    """Re-apply the action this annotator most recently undid on this image."""
+    return await _apply(image_id, db, user, redo=True)

--- a/app/routes/general/contours.py
+++ b/app/routes/general/contours.py
@@ -9,6 +9,7 @@ from app.database import get_session
 from app.database.contours import Contours
 from app.schemas.auth_user import AuthenticatedUser
 from app.schemas.permissions import Permission
+from app.services.database_access import annotation_history as history_db
 from app.services.database_access import contours as contours_db
 from app.services.permissions import ensure_permission_for, require
 
@@ -72,12 +73,16 @@ async def modify_contour(
     Returns:
         dict: A dictionary containing the success status, message, and the ID of the edited contour.
     """
-    await _ensure_may_edit(contour_id, user, db)
+    contour = await _ensure_may_edit(contour_id, user, db)
+    previous_label_id, mask_id = contour.label_id, contour.mask_id
     # `reviewed_by` is a review action, not an edit: setting it here would let an
     # annotator approve their own work through the back door.
     kwargs.pop("reviewed_by", None)
     kwargs.pop("author_username", None)
     modified = await contours_db.modify_contour(contour_id, db, **kwargs)
+    if modified and "label_id" in kwargs:
+        history_db.record_label_change(db, mask_id, user.username, contour_id,
+                                       previous_label_id, kwargs["label_id"])
     return {
         "success": modified,
         "message": "Contour updated successfully." if modified else "Contour could not be updated.",
@@ -127,10 +132,13 @@ async def change_contour_label(
     """
     dataset_id = ensure_permission_for(user, "contour_id", contour_id,
                                        Permission.ANNOTATION_EDIT_OWN, db)
-    await _ensure_may_edit(contour_id, user, db)
+    contour = await _ensure_may_edit(contour_id, user, db)
+    previous_label_id, mask_id = contour.label_id, contour.mask_id
 
     # 1. Change the label_id, this checks if the new label is valid
     await contours_db.modify_contour(contour_id, label_id=new_label_id, db=db)
+    history_db.record_label_change(db, mask_id, user.username, contour_id,
+                                   previous_label_id, new_label_id)
 
     # 2. Record a review only if this caller is entitled to give one
     reviewed = False
@@ -215,8 +223,13 @@ async def delete_contour(
     Delete a contour and all its descendants (via CASCADE).
     Returns the list of deleted contour IDs.
     """
-    await _ensure_may_edit(contour_id, user, db)
+    contour = await _ensure_may_edit(contour_id, user, db)
+    mask_id = contour.mask_id
+    # Taken before the delete: the CASCADE removes the descendants too, and undo
+    # has to be able to bring the whole subtree back.
+    snapshot = history_db.snapshot_subtree(contour_id, db)
     await contours_db.delete_contour(contour_id, db)
+    history_db.record_delete(db, mask_id, user.username, snapshot)
 
     return {
         "success": True,

--- a/app/routes/websockets/annotation_handlers.py
+++ b/app/routes/websockets/annotation_handlers.py
@@ -36,6 +36,7 @@ from app.services import image_status
 from app.services.annotation_session.state import AnnotationSessionState, Backends
 from app.services.auth import load_user
 from app.services.permissions import dataset_id_for_image
+from app.services.database_access import annotation_history as history_db
 from app.services.database_access import contours as contours_db
 from app.services.database_access import labels as labels_db
 from app.services.database_access import masks as masks_db
@@ -324,7 +325,11 @@ async def handle_object_delete(websocket: WebSocket, client_msg: ClientMessage, 
     """ Handle removing an object from the mask. """
     contour_id = client_msg.data.get("contour_id")
     with get_context_session() as db:
-        response = await contours_db.delete_contour(contour_id, db)
+        # Snapshot first: the delete cascades to the descendants, so once it has
+        # run there is nothing left to describe what undo would have to bring back.
+        snapshot = history_db.snapshot_subtree(contour_id, db)
+        await contours_db.delete_contour(contour_id, db)
+        history_db.record_delete(db, state.mask_id, state.user_id, snapshot)
     await send_msg(websocket, ServerMessage(
         id=client_msg.id,
         type=ServerMessageType.OBJECT_REMOVED,
@@ -362,8 +367,15 @@ async def handle_object_modify(websocket: WebSocket, client_msg: ClientMessage, 
             await _deny(websocket, client_msg, Permission.ANNOTATION_EDIT_ANY)
             return
 
+        # Read the label before the update so the history knows what to go back to.
+        previous_label_id = existing.label_id if existing is not None else None
+
         if fields_to_be_updated:
             await contours_db.modify_contour(contour_id, db=db, **fields_to_be_updated)
+            if assigns_label:
+                history_db.record_label_change(db, state.mask_id, state.user_id, contour_id,
+                                               previous_label_id,
+                                               fields_to_be_updated["label_id"])
 
         # Assigning a label counts as a review only for callers entitled to give
         # one; for everyone else the label change simply stands on its own.
@@ -585,8 +597,11 @@ async def handle_suggestion(websocket: WebSocket, client_msg: ClientMessage, sta
         message=result.message,
         data={"added_count": len(suggested)},
     ))
+    # One suggestion run is one thing the user did, so it is one undo step however
+    # many instances came back.
+    group_id = history_db.new_group_id()
     for contour in suggested:
-        await add_object(contour, websocket, client_msg, state)
+        await add_object(contour, websocket, client_msg, state, group_id=group_id)
 
 
 async def handle_instance_select_model(websocket: WebSocket, client_msg: ClientMessage,
@@ -663,7 +678,20 @@ async def handle_instance_segmentation(websocket: WebSocket, client_msg: ClientM
 
 
 async def add_object(object_to_add: Contour, websocket: WebSocket, client_msg: ClientMessage,
-                     state: AnnotationSessionState):
+                     state: AnnotationSessionState, group_id: str | None = None):
+    """Persist one new object and tell the client about it.
+
+    Every interactive add reaches the database through here -- manual drawing,
+    prompted segmentation and instance suggestion alike -- which makes it the one
+    place the undo history has to be told about a creation. Instance segmentation
+    is the exception, and deliberately so: it wipes and repopulates the mask
+    through ``masks_db`` directly, and a per-object undo of half a replace-all
+    would leave the mask in a state the user never saw.
+
+    Args:
+        group_id: Ties this creation to others made in the same operation, so a
+            suggestion run that adds thirty objects is undone in one step.
+    """
     with get_context_session() as db:
         response = await masks_db.add_contour_to_mask(
             mask_id=state.mask_id,
@@ -671,6 +699,8 @@ async def add_object(object_to_add: Contour, websocket: WebSocket, client_msg: C
             db=db,
             author_username=state.user_id,
         )
+        history_db.record_create(db, state.mask_id, state.user_id, response.id,
+                                 group_id=group_id)
     await send_msg(websocket, ServerMessage(
         id=client_msg.id,
         type=ServerMessageType.OBJECT_ADDED,

--- a/app/services/database_access/annotation_history.py
+++ b/app/services/database_access/annotation_history.py
@@ -1,0 +1,465 @@
+"""Recording and replaying the annotator's action history (undo / redo).
+
+The module has two halves:
+
+  * ``record_*`` -- called by the write paths (the WebSocket handlers and the REST
+    contour routes) right after they change something. Each call appends one row to
+    ``annotation_actions`` and discards whatever redo branch was outstanding.
+  * ``undo`` / ``redo`` -- pop the newest row off the appropriate stack and apply
+    it in the corresponding direction.
+
+Every row carries enough state to go BOTH ways, so undo and redo read the same
+row and only differ in which direction they apply it. That is what makes
+``create`` and ``delete`` one implementation: undoing a create *is* deleting, and
+redoing it *is* restoring, which is exactly what undo/redo of a delete does with
+the arrows reversed.
+
+Restoration is faithful where it can be and honest where it cannot. A restored
+contour keeps its id, its children, its label, its author and its approvals. But
+the world may have moved on since the action was recorded -- the parent contour
+may itself have been deleted, a label may have been removed from the dataset, a
+reviewer's account may be gone. Rather than fail with a foreign-key error or
+silently write a dangling reference, each of those cases degrades to something
+defensible and says so in the returned message.
+"""
+import uuid
+from datetime import datetime
+from logging import getLogger
+
+from sqlalchemy.orm import Session
+
+from app.database.annotation_actions import (
+    MAX_HISTORY_ENTRIES,
+    ActionType,
+    AnnotationActions,
+)
+from app.database.contours import Contours, dual_write_geometry_metrics
+from app.database.labels import Labels
+from app.database.masks import Masks
+from app.database.users import Users
+from app.services import hierarchy_cache
+from app.services.database_access.contours import (
+    invalidate_metrics_for_new_contours,
+    mark_contextual_stale_for_group,
+    mark_relational_stale_for_parent,
+)
+
+logger = getLogger(__name__)
+
+
+class HistoryError(Exception):
+    """A history step could not be applied. The message is shown to the user."""
+
+
+# --- Snapshots ----------------------------------------------------------------
+
+
+def _serialize_contour(contour: Contours) -> dict:
+    """One contour row as JSON, complete enough to re-create it exactly."""
+    return {
+        "id": contour.id,
+        "parent_id": contour.parent_id,
+        "label_id": contour.label_id,
+        "x": list(contour.x or []),
+        "y": list(contour.y or []),
+        "added_by": contour.added_by,
+        "author_username": contour.author_username,
+        "confidence_score": contour.confidence_score,
+        "temporary": bool(contour.temporary),
+        "created_at": contour.created_at.isoformat() if contour.created_at else None,
+        "reviewed_by": [reviewer.username for reviewer in contour.reviewed_by],
+    }
+
+
+def snapshot_subtree(contour_id: int, db: Session) -> dict | None:
+    """Capture a contour and everything nested under it.
+
+    Called before a deletion, because afterwards the rows (and, via the CASCADE,
+    every descendant) are gone. The contours are laid out parents-first so a
+    restore can insert them in list order without ever pointing a ``parent_id`` at
+    a row that does not exist yet.
+
+    Args:
+        contour_id: The contour about to be deleted or just created.
+        db: The database session.
+
+    Returns:
+        ``{"root_id": int, "contours": [...]}``, or ``None`` if the contour is gone.
+    """
+    root = db.query(Contours).filter_by(id=contour_id).first()
+    if root is None:
+        return None
+
+    serialized = []
+    queue = [root]
+    while queue:
+        contour = queue.pop(0)
+        serialized.append(_serialize_contour(contour))
+        queue.extend(
+            db.query(Contours).filter_by(parent_id=contour.id).order_by(Contours.id).all()
+        )
+
+    return {"root_id": root.id, "contours": serialized}
+
+
+def _restore_subtree(mask_id: int, snapshot: dict, db: Session) -> tuple[list[Contours], list[str]]:
+    """Re-insert a snapshotted subtree under its original ids.
+
+    Returns the created rows plus any human-readable notes about state that could
+    not be restored faithfully (a vanished parent, label or reviewer).
+    """
+    notes: list[str] = []
+    restored: list[Contours] = []
+    # Ids that came back in this call, so a child whose parent is restored in the
+    # same pass is not mistaken for one whose parent is gone.
+    revived_ids: set[int] = set()
+
+    for entry in snapshot.get("contours", []):
+        contour_id = entry["id"]
+        if db.query(Contours.id).filter_by(id=contour_id).first() is not None:
+            # Something already occupies this id -- the action was undone twice, or
+            # the id was reused. Skip rather than trample the current occupant.
+            continue
+
+        parent_id = entry.get("parent_id")
+        if parent_id is not None and parent_id not in revived_ids:
+            if db.query(Contours.id).filter_by(id=parent_id).first() is None:
+                # The object this one was nested inside has since been deleted.
+                # Bringing it back at the top level keeps the geometry rather than
+                # failing the whole undo on a foreign key.
+                notes.append("its parent object no longer exists, so it was "
+                             "restored at the top level")
+                parent_id = None
+
+        label_id = entry.get("label_id")
+        if label_id is not None and db.query(Labels.id).filter_by(id=label_id).first() is None:
+            notes.append("its label has since been removed from the dataset")
+            label_id = None
+
+        created_at = entry.get("created_at")
+        contour = Contours(
+            id=contour_id,
+            mask_id=mask_id,
+            parent_id=parent_id,
+            label_id=label_id,
+            temporary=entry.get("temporary", False),
+            added_by=entry.get("added_by") or "User",
+            author_username=entry.get("author_username"),
+            confidence_score=entry.get("confidence_score", 1.0),
+            created_at=datetime.fromisoformat(created_at) if created_at else None,
+            x=entry.get("x") or [],
+            y=entry.get("y") or [],
+            # NOT NULL columns; dual_write_geometry_metrics recomputes them below
+            # from the coordinates, which is also what the original write did.
+            area=0.0, perimeter=0.0, circularity=0.0, diameter=0.0,
+        )
+        db.add(contour)
+        db.flush()
+        revived_ids.add(contour_id)
+
+        reviewers = entry.get("reviewed_by") or []
+        if reviewers:
+            found = db.query(Users).filter(Users.username.in_(reviewers)).all()
+            contour.reviewed_by = found
+            if len(found) != len(reviewers):
+                notes.append("some reviewers of it no longer have accounts")
+
+        restored.append(contour)
+
+    if restored:
+        dual_write_geometry_metrics(db, mask_id, restored)
+        invalidate_metrics_for_new_contours(db, restored)
+        # The contours are exemplars again now that they exist; no-op unless the
+        # embedding lifecycle is enabled. Local import: embedding_lifecycle reaches
+        # back into the contour modules this one already imports.
+        from app.services.embedding_lifecycle import enqueue_embed_contours
+        enqueue_embed_contours([c.id for c in restored if not c.temporary])
+
+    # Dedupe while preserving order -- a 20-contour subtree should not report the
+    # same missing label twenty times.
+    return restored, list(dict.fromkeys(notes))
+
+
+def _delete_subtree_root(contour_id: int, db: Session) -> bool:
+    """Delete one contour and, by CASCADE, its descendants. False if already gone."""
+    contour = db.query(Contours).filter_by(id=contour_id).first()
+    if contour is None:
+        return False
+    mask_id, parent_id = contour.mask_id, contour.parent_id
+    # Same invalidation the ordinary delete path does: the surviving siblings lost
+    # a neighbour and the parent lost a child.
+    mark_contextual_stale_for_group(db, mask_id, parent_id)
+    mark_relational_stale_for_parent(db, [parent_id])
+    db.delete(contour)
+    db.flush()
+    return True
+
+
+# --- Recording ----------------------------------------------------------------
+
+
+def new_group_id() -> str:
+    """An id tying several recorded actions into one undo step."""
+    return uuid.uuid4().hex
+
+
+def clear_for_mask(mask_id: int, db: Session) -> None:
+    """Discard every annotator's history for a mask. Does not commit.
+
+    Called when something replaces a mask's contours wholesale rather than object
+    by object -- "Remove all annotations", instance segmentation, batch inference.
+    The recorded steps describe contours that no longer exist, and worse, are not
+    merely inert: undoing a delete recorded before the wipe would re-insert that
+    contour into a mask the user had just emptied, resurrecting one object out of
+    a set the user deliberately cleared.
+
+    Undo cannot span an operation it has no inverse for, so the honest thing is to
+    start the history over at that point rather than let it reach across.
+    """
+    (db.query(AnnotationActions)
+     .filter(AnnotationActions.mask_id == mask_id)
+     .delete(synchronize_session=False))
+
+
+def _prune(db: Session, mask_id: int, username: str) -> None:
+    """Drop the oldest steps beyond ``MAX_HISTORY_ENTRIES``.
+
+    Counts STEPS, not rows: a grouped action (one suggestion run adding thirty
+    objects) is one step, and is kept or dropped whole. Pruning half a group would
+    leave an undo that restores two thirds of what the user sees.
+    """
+    rows = (db.query(AnnotationActions)
+            .filter_by(mask_id=mask_id, username=username)
+            .order_by(AnnotationActions.id.desc())
+            .all())
+
+    kept_steps: list[str] = []
+    doomed: list[int] = []
+    for row in rows:
+        step = row.group_id or f"solo:{row.id}"
+        if step in kept_steps:
+            continue
+        if len(kept_steps) < MAX_HISTORY_ENTRIES:
+            kept_steps.append(step)
+        else:
+            doomed.append(row.id)
+
+    if doomed:
+        (db.query(AnnotationActions)
+         .filter(AnnotationActions.id.in_(doomed))
+         .delete(synchronize_session=False))
+
+
+def _record(db: Session, mask_id: int, username: str, action_type: str,
+            payload: dict, group_id: str | None = None) -> None:
+    """Append one row and invalidate the redo branch."""
+    if mask_id is None or not username:
+        return
+    # A fresh action makes the undone steps unreachable: there is no coherent
+    # state to redo them onto any more.
+    (db.query(AnnotationActions)
+     .filter_by(mask_id=mask_id, username=username, undone=True)
+     .delete(synchronize_session=False))
+
+    db.add(AnnotationActions(
+        mask_id=mask_id,
+        username=username,
+        group_id=group_id,
+        action_type=action_type,
+        payload=payload,
+        undone=False,
+    ))
+    _prune(db, mask_id, username)
+    db.commit()
+
+
+def record_create(db: Session, mask_id: int, username: str, contour_id: int,
+                  group_id: str | None = None) -> None:
+    """Record that ``contour_id`` was just added to the mask."""
+    snapshot = snapshot_subtree(contour_id, db)
+    if snapshot is None:
+        return
+    _record(db, mask_id, username, ActionType.CREATE,
+            {"contour_id": contour_id, "snapshot": snapshot}, group_id)
+
+
+def record_delete(db: Session, mask_id: int, username: str, snapshot: dict,
+                  group_id: str | None = None) -> None:
+    """Record a deletion. ``snapshot`` must come from :func:`snapshot_subtree`
+    taken BEFORE the rows were removed."""
+    if not snapshot:
+        return
+    _record(db, mask_id, username, ActionType.DELETE,
+            {"contour_id": snapshot["root_id"], "snapshot": snapshot}, group_id)
+
+
+def record_label_change(db: Session, mask_id: int, username: str, contour_id: int,
+                        before_label_id: int | None, after_label_id: int | None,
+                        group_id: str | None = None) -> None:
+    """Record a relabelling. A no-op change records nothing."""
+    if before_label_id == after_label_id:
+        return
+    _record(db, mask_id, username, ActionType.LABEL, {
+        "contour_id": contour_id,
+        "before_label_id": before_label_id,
+        "after_label_id": after_label_id,
+    }, group_id)
+
+
+# --- Applying -----------------------------------------------------------------
+
+
+def _apply_create(payload: dict, mask_id: int, db: Session, forward: bool) -> str:
+    """Apply a ``create`` step. Forward re-adds the contour, backward removes it."""
+    contour_id = payload["contour_id"]
+    if forward:
+        restored, notes = _restore_subtree(mask_id, payload["snapshot"], db)
+        if not restored:
+            raise HistoryError("That object is already on the image.")
+        return _with_notes("Object restored", notes)
+
+    snapshot = payload.get("snapshot") or {}
+    known_ids = {entry["id"] for entry in snapshot.get("contours", [])}
+    later_children = db.query(Contours.id).filter(Contours.parent_id == contour_id)
+    if known_ids:
+        later_children = later_children.filter(Contours.id.notin_(known_ids))
+    if later_children.first() is not None:
+        # Undoing the creation would cascade-delete work that was nested inside it
+        # afterwards, which the user never asked to undo.
+        raise HistoryError("This object now contains other objects. Delete or move "
+                           "them before undoing it.")
+    if not _delete_subtree_root(contour_id, db):
+        raise HistoryError("That object is no longer on the image.")
+    return "Object removed"
+
+
+def _apply_label(payload: dict, db: Session, forward: bool) -> str:
+    """Apply a ``label`` step in the given direction."""
+    contour_id = payload["contour_id"]
+    target = payload["after_label_id"] if forward else payload["before_label_id"]
+
+    contour = db.query(Contours).filter_by(id=contour_id).first()
+    if contour is None:
+        raise HistoryError("That object no longer exists.")
+    if target is not None and db.query(Labels.id).filter_by(id=target).first() is None:
+        raise HistoryError("That label has since been removed from the dataset.")
+
+    contour.label_id = target
+    # A label change moves the contour between label-filtered neighbour sets.
+    mark_contextual_stale_for_group(db, contour.mask_id, contour.parent_id)
+    db.flush()
+    return "Label restored" if not forward else "Label reapplied"
+
+
+def _with_notes(message: str, notes: list[str]) -> str:
+    return f"{message} ({'; '.join(notes)})" if notes else message
+
+
+def _apply(row: AnnotationActions, db: Session, forward: bool) -> str:
+    """Apply one recorded row forwards (redo) or backwards (undo)."""
+    if row.action_type == ActionType.CREATE:
+        return _apply_create(row.payload, row.mask_id, db, forward)
+    if row.action_type == ActionType.DELETE:
+        # A delete is a create with the arrows swapped: undoing it restores.
+        return _apply_create(row.payload, row.mask_id, db, not forward)
+    if row.action_type == ActionType.LABEL:
+        return _apply_label(row.payload, db, forward)
+    raise HistoryError(f"Unknown action type {row.action_type!r}.")
+
+
+def _newest_step(db: Session, mask_id: int, username: str,
+                 undone: bool) -> list[AnnotationActions]:
+    """The rows making up the top step of one stack, oldest row first.
+
+    A grouped action returns all of its rows; an ordinary one returns a single-item
+    list. Callers apply the list in whichever order their direction needs.
+    """
+    newest = (db.query(AnnotationActions)
+              .filter_by(mask_id=mask_id, username=username, undone=undone)
+              .order_by(AnnotationActions.id.desc())
+              .first())
+    if newest is None:
+        return []
+    if newest.group_id is None:
+        return [newest]
+    return (db.query(AnnotationActions)
+            .filter_by(mask_id=mask_id, username=username, undone=undone,
+                       group_id=newest.group_id)
+            .order_by(AnnotationActions.id.asc())
+            .all())
+
+
+_DESCRIPTIONS = {
+    ActionType.CREATE: "add object",
+    ActionType.DELETE: "delete object",
+    ActionType.LABEL: "label change",
+}
+
+
+def _describe(rows: list[AnnotationActions]) -> str | None:
+    """A short label for the step, for the toolbar tooltip."""
+    if not rows:
+        return None
+    base = _DESCRIPTIONS.get(rows[0].action_type, "change")
+    return f"{base} (×{len(rows)})" if len(rows) > 1 else base
+
+
+def mask_id_for_image(image_id: int, db: Session) -> int | None:
+    return db.query(Masks.id).filter_by(image_id=image_id).scalar()
+
+
+def get_status(mask_id: int, username: str, db: Session) -> dict:
+    """What the undo and redo buttons should show right now."""
+    undo_rows = _newest_step(db, mask_id, username, undone=False)
+    redo_rows = _newest_step(db, mask_id, username, undone=True)
+    return {
+        "can_undo": bool(undo_rows),
+        "can_redo": bool(redo_rows),
+        "undo_label": _describe(undo_rows),
+        "redo_label": _describe(redo_rows),
+    }
+
+
+def _run(mask_id: int, username: str, db: Session, forward: bool) -> dict:
+    """Shared body of undo and redo.
+
+    Undo takes the newest not-yet-undone step and applies it backwards, newest row
+    first so a grouped action unwinds in the reverse of the order it was made.
+    Redo takes the newest undone step and applies it forwards in original order.
+    """
+    rows = _newest_step(db, mask_id, username, undone=forward)
+    if not rows:
+        raise HistoryError("There is nothing to redo." if forward
+                           else "There is nothing to undo.")
+
+    ordered = rows if forward else list(reversed(rows))
+    messages = []
+    try:
+        for row in ordered:
+            messages.append(_apply(row, db, forward))
+            row.undone = not forward
+        db.commit()
+    except HistoryError:
+        db.rollback()
+        raise
+    except Exception:
+        db.rollback()
+        logger.exception("Failed to %s an annotation action on mask %s.",
+                         "redo" if forward else "undo", mask_id)
+        raise HistoryError("That step could not be applied.")
+
+    hierarchy_cache.invalidate(mask_id)
+    message = messages[0] if len(set(messages)) == 1 else "; ".join(messages)
+    if len(rows) > 1:
+        message = f"{message} ×{len(rows)}"
+    return {"action_type": rows[0].action_type, "message": message}
+
+
+def undo(mask_id: int, username: str, db: Session) -> dict:
+    """Revert this annotator's most recent step on this image."""
+    return _run(mask_id, username, db, forward=False)
+
+
+def redo(mask_id: int, username: str, db: Session) -> dict:
+    """Re-apply the step this annotator most recently undid on this image."""
+    return _run(mask_id, username, db, forward=True)

--- a/app/services/database_access/masks.py
+++ b/app/services/database_access/masks.py
@@ -241,10 +241,16 @@ async def delete_all_contours_of_mask(
         db: Session,
         unreviewed_only: bool = False,
 ):
+    # Local import: annotation_history reaches back into the contour access layer.
+    from app.services.database_access.annotation_history import clear_for_mask
+
     if unreviewed_only:
         db.query(Contours).filter(Contours.mask_id == mask_id, ~Contours.reviewed_by.any()).delete()
     else:
         db.query(Contours).filter_by(mask_id=mask_id).delete()
+    # The undo history describes contours that are gone now. Left in place, an undo
+    # recorded before this wipe would put one of them back into the emptied mask.
+    clear_for_mask(mask_id, db)
     mask = db.query(Masks).filter_by(id=mask_id).first()
     mask.fully_annotated = False
     db.commit()

--- a/tests/test_annotation_history.py
+++ b/tests/test_annotation_history.py
@@ -1,0 +1,380 @@
+"""Tests for the annotator's undo / redo history.
+
+The feature's whole promise is that undoing a delete gives back *the object you
+deleted* -- not a lookalike. So most of what is checked here is identity and
+completeness of the restore: the same contour id, the nested children, the label,
+the author, the approvals. A client-side undo stack could satisfy none of that,
+which is why the history lives in the database at all.
+
+The rest covers the stack semantics people expect from Ctrl+Z: a new edit kills
+the redo branch, one annotator's undo cannot touch another's work, a fan-out
+operation costs one step rather than thirty, and the log stays bounded.
+"""
+import asyncio
+
+import pytest
+from sqlalchemy import create_engine, event
+from sqlalchemy.engine import Engine
+from sqlalchemy.orm import sessionmaker
+
+from app.database import database
+import app.database.annotation_actions  # noqa: F401
+import app.database.datasets  # noqa: F401
+import app.database.images  # noqa: F401
+import app.database.labels  # noqa: F401
+import app.database.masks  # noqa: F401
+import app.database.users  # noqa: F401
+import app.database.contours  # noqa: F401  (also pulls in contour_metrics)
+from app.database.annotation_actions import MAX_HISTORY_ENTRIES, AnnotationActions
+from app.database.contours import Contours, save_contour_tree
+from app.database.datasets import Datasets
+from app.database.images import Images
+from app.database.labels import Labels
+from app.database.masks import Masks
+from app.database.users import Users
+from app.services import hierarchy_cache
+from app.services.database_access import annotation_history as history_db
+from app.services.database_access import contours as contours_db
+from app.services.database_access import masks as masks_db
+
+from iquana_toolbox.schemas.database.contours import Contour
+
+WIDTH, HEIGHT = 1000, 1000
+ANNOTATOR = "ann"
+OTHER = "other"
+
+
+@event.listens_for(Engine, "connect")
+def _fk_pragma(dbapi_connection, connection_record):
+    import sqlite3
+    if isinstance(dbapi_connection, sqlite3.Connection):
+        cur = dbapi_connection.cursor()
+        cur.execute("PRAGMA foreign_keys=ON")
+        cur.close()
+
+
+@pytest.fixture
+def session(tmp_path):
+    engine = create_engine(f"sqlite:///{tmp_path / 'test.db'}")
+    database.metadata.create_all(engine)
+    Session = sessionmaker(bind=engine)
+    s = Session()
+    hierarchy_cache.clear()
+    try:
+        yield s
+    finally:
+        hierarchy_cache.clear()
+        s.close()
+        engine.dispose()
+
+
+def _contour(cx_px, cy_px, half=20, label_id=None, parent_id=None):
+    x_px = [cx_px - half, cx_px + half, cx_px + half, cx_px - half]
+    y_px = [cy_px - half, cy_px - half, cy_px + half, cy_px + half]
+    return Contour(
+        x=[x / WIDTH for x in x_px],
+        y=[y / HEIGHT for y in y_px],
+        added_by="User",
+        confidence=1.0,
+        label_id=label_id,
+        parent_id=parent_id,
+    )
+
+
+@pytest.fixture
+def world(session):
+    """One dataset / image / mask, two labels, and two annotators."""
+    session.add_all([
+        Users(username=ANNOTATOR, hashed_password="x", is_admin=False),
+        Users(username=OTHER, hashed_password="x", is_admin=False),
+    ])
+    dataset = Datasets(name="hist", description="", dataset_type="image",
+                       folder_path="/tmp/hist", created_by=ANNOTATOR)
+    session.add(dataset)
+    session.flush()
+
+    coral = Labels(dataset_id=dataset.id, name="coral", value=1)
+    algae = Labels(dataset_id=dataset.id, name="algae", value=2)
+    session.add_all([coral, algae])
+
+    image = Images(dataset_id=dataset.id, file_name="a.png", file_path="/tmp/a.png",
+                   thumbnail_file_path="/tmp/t.png", width=WIDTH, height=HEIGHT,
+                   color_mode="RGB", scale_x=1.0, scale_y=1.0, unit="px")
+    session.add(image)
+    session.flush()
+
+    mask = Masks(image_id=image.id, fully_annotated=False, file_path="/tmp/m.png")
+    session.add(mask)
+    session.commit()
+    return {"mask": mask, "image": image, "coral": coral, "algae": algae}
+
+
+def _add(session, mask, cx=100, cy=100, half=20, label_id=None, parent_id=None,
+         author=ANNOTATOR):
+    """Save a contour and return its row."""
+    row = save_contour_tree(session, _contour(cx, cy, half, label_id, parent_id),
+                            mask.id, parent_id=parent_id, author_username=author)
+    session.commit()
+    return row
+
+
+def _delete_with_history(session, mask, contour_id, username=ANNOTATOR):
+    """The delete path as the handlers run it: snapshot, delete, record."""
+    snapshot = history_db.snapshot_subtree(contour_id, session)
+    asyncio.run(contours_db.delete_contour(contour_id, session))
+    history_db.record_delete(session, mask.id, username, snapshot)
+
+
+def _ids(session, mask):
+    return {row.id for row in session.query(Contours).filter_by(mask_id=mask.id).all()}
+
+
+# --------------------------------------------------------------------------- #
+# Undoing a delete -- the case in the issue
+# --------------------------------------------------------------------------- #
+def test_undoing_a_delete_restores_the_same_contour(session, world):
+    mask = world["mask"]
+    contour = _add(session, mask, label_id=world["coral"].id)
+    contour_id = contour.id
+
+    _delete_with_history(session, mask, contour_id)
+    assert _ids(session, mask) == set()
+
+    history_db.undo(mask.id, ANNOTATOR, session)
+
+    restored = session.query(Contours).filter_by(id=contour_id).one()
+    # The id is the point: everything else in the system references the object by
+    # it, so a restore under a fresh id would be a different object wearing its face.
+    assert restored.id == contour_id
+    assert restored.label_id == world["coral"].id
+    assert restored.author_username == ANNOTATOR
+    assert restored.mask_id == mask.id
+
+
+def test_undoing_a_delete_restores_nested_children(session, world):
+    """The delete cascades to descendants, so the undo has to bring them all back."""
+    mask = world["mask"]
+    # Plain ints, not ORM rows: the cascade delete below detaches the instances.
+    parent_id = _add(session, mask, half=100).id
+    child_id = _add(session, mask, half=10, parent_id=parent_id).id
+    grandchild_id = _add(session, mask, half=4, parent_id=child_id).id
+
+    _delete_with_history(session, mask, parent_id)
+    assert _ids(session, mask) == set()
+
+    history_db.undo(mask.id, ANNOTATOR, session)
+
+    assert _ids(session, mask) == {parent_id, child_id, grandchild_id}
+    assert session.query(Contours).filter_by(id=child_id).one().parent_id == parent_id
+    assert session.query(Contours).filter_by(id=grandchild_id).one().parent_id == child_id
+
+
+def test_undoing_a_delete_restores_approvals(session, world):
+    mask = world["mask"]
+    contour = _add(session, mask)
+    reviewer = session.query(Users).filter_by(username=OTHER).one()
+    contour.reviewed_by = [reviewer]
+    session.commit()
+    contour_id = contour.id
+
+    _delete_with_history(session, mask, contour_id)
+    history_db.undo(mask.id, ANNOTATOR, session)
+
+    restored = session.query(Contours).filter_by(id=contour_id).one()
+    assert [user.username for user in restored.reviewed_by] == [OTHER]
+
+
+def test_redo_deletes_the_restored_contour_again(session, world):
+    mask = world["mask"]
+    contour_id = _add(session, mask).id
+
+    _delete_with_history(session, mask, contour_id)
+    history_db.undo(mask.id, ANNOTATOR, session)
+    assert _ids(session, mask) == {contour_id}
+
+    history_db.redo(mask.id, ANNOTATOR, session)
+    assert _ids(session, mask) == set()
+
+
+def test_restore_survives_a_parent_that_is_gone(session, world):
+    """A vanished parent must degrade to a top-level restore, not a foreign-key error."""
+    mask = world["mask"]
+    parent = _add(session, mask, half=100)
+    child = _add(session, mask, half=10, parent_id=parent.id)
+    child_id = child.id
+
+    _delete_with_history(session, mask, child_id)
+    # The parent goes away between the delete and the undo, without history.
+    asyncio.run(contours_db.delete_contour(parent.id, session))
+
+    history_db.undo(mask.id, ANNOTATOR, session)
+
+    restored = session.query(Contours).filter_by(id=child_id).one()
+    assert restored.parent_id is None
+
+
+# --------------------------------------------------------------------------- #
+# Undoing a create
+# --------------------------------------------------------------------------- #
+def test_undoing_a_create_removes_the_object_and_redo_brings_it_back(session, world):
+    mask = world["mask"]
+    contour_id = _add(session, mask, label_id=world["algae"].id).id
+    history_db.record_create(session, mask.id, ANNOTATOR, contour_id)
+
+    history_db.undo(mask.id, ANNOTATOR, session)
+    assert _ids(session, mask) == set()
+
+    history_db.redo(mask.id, ANNOTATOR, session)
+    restored = session.query(Contours).filter_by(id=contour_id).one()
+    assert restored.label_id == world["algae"].id
+
+
+def test_undoing_a_create_refuses_when_work_was_nested_inside(session, world):
+    """Undo must not cascade away objects the user added inside it afterwards."""
+    mask = world["mask"]
+    parent_id = _add(session, mask, half=100).id
+    history_db.record_create(session, mask.id, ANNOTATOR, parent_id)
+    child_id = _add(session, mask, half=10, parent_id=parent_id).id
+
+    with pytest.raises(history_db.HistoryError):
+        history_db.undo(mask.id, ANNOTATOR, session)
+
+    assert _ids(session, mask) == {parent_id, child_id}
+
+
+# --------------------------------------------------------------------------- #
+# Label changes
+# --------------------------------------------------------------------------- #
+def test_label_change_round_trips(session, world):
+    mask = world["mask"]
+    contour = _add(session, mask, label_id=world["coral"].id)
+    contour.label_id = world["algae"].id
+    session.commit()
+    history_db.record_label_change(session, mask.id, ANNOTATOR, contour.id,
+                                   world["coral"].id, world["algae"].id)
+
+    history_db.undo(mask.id, ANNOTATOR, session)
+    assert session.query(Contours).filter_by(id=contour.id).one().label_id == world["coral"].id
+
+    history_db.redo(mask.id, ANNOTATOR, session)
+    assert session.query(Contours).filter_by(id=contour.id).one().label_id == world["algae"].id
+
+
+def test_a_label_change_that_changes_nothing_is_not_recorded(session, world):
+    mask = world["mask"]
+    contour = _add(session, mask, label_id=world["coral"].id)
+
+    history_db.record_label_change(session, mask.id, ANNOTATOR, contour.id,
+                                   world["coral"].id, world["coral"].id)
+
+    assert history_db.get_status(mask.id, ANNOTATOR, session)["can_undo"] is False
+
+
+# --------------------------------------------------------------------------- #
+# Stack semantics
+# --------------------------------------------------------------------------- #
+def test_a_new_action_discards_the_redo_branch(session, world):
+    mask = world["mask"]
+    first_id = _add(session, mask).id
+    _delete_with_history(session, mask, first_id)
+    history_db.undo(mask.id, ANNOTATOR, session)
+    assert history_db.get_status(mask.id, ANNOTATOR, session)["can_redo"] is True
+
+    second_id = _add(session, mask, cx=500, cy=500).id
+    history_db.record_create(session, mask.id, ANNOTATOR, second_id)
+
+    status = history_db.get_status(mask.id, ANNOTATOR, session)
+    assert status["can_redo"] is False
+    assert status["can_undo"] is True
+
+
+def test_one_annotators_stack_is_invisible_to_another(session, world):
+    mask = world["mask"]
+    contour_id = _add(session, mask).id
+    _delete_with_history(session, mask, contour_id, username=ANNOTATOR)
+
+    assert history_db.get_status(mask.id, OTHER, session)["can_undo"] is False
+    with pytest.raises(history_db.HistoryError):
+        history_db.undo(mask.id, OTHER, session)
+    # And the other annotator's own undo is unaffected.
+    assert history_db.get_status(mask.id, ANNOTATOR, session)["can_undo"] is True
+
+
+def test_a_grouped_run_is_one_undo_step(session, world):
+    """Thirty suggested instances should cost one Ctrl+Z, not thirty."""
+    mask = world["mask"]
+    group = history_db.new_group_id()
+    ids = set()
+    for index in range(5):
+        contour_id = _add(session, mask, cx=100 + index * 100, cy=100, half=20).id
+        history_db.record_create(session, mask.id, ANNOTATOR, contour_id, group_id=group)
+        ids.add(contour_id)
+
+    history_db.undo(mask.id, ANNOTATOR, session)
+    assert _ids(session, mask) == set()
+
+    history_db.redo(mask.id, ANNOTATOR, session)
+    assert _ids(session, mask) == ids
+
+
+def test_history_is_capped(session, world):
+    mask = world["mask"]
+    for index in range(MAX_HISTORY_ENTRIES + 4):
+        contour_id = _add(session, mask, cx=50 + index * 30, cy=50, half=10).id
+        history_db.record_create(session, mask.id, ANNOTATOR, contour_id)
+
+    kept = session.query(AnnotationActions).filter_by(mask_id=mask.id,
+                                                      username=ANNOTATOR).count()
+    assert kept == MAX_HISTORY_ENTRIES
+
+
+def test_status_describes_the_next_step(session, world):
+    mask = world["mask"]
+    contour_id = _add(session, mask).id
+    _delete_with_history(session, mask, contour_id)
+
+    status = history_db.get_status(mask.id, ANNOTATOR, session)
+    assert status["undo_label"] == "delete object"
+    assert status["redo_label"] is None
+
+
+def test_undo_on_an_empty_stack_is_an_error(session, world):
+    with pytest.raises(history_db.HistoryError):
+        history_db.undo(world["mask"].id, ANNOTATOR, session)
+
+
+# --------------------------------------------------------------------------- #
+# Operations the history cannot span
+# --------------------------------------------------------------------------- #
+def test_wiping_a_mask_discards_the_history(session, world):
+    """Undo must not reach across a wholesale replacement of the mask.
+
+    Without this, deleting one object and then clearing the whole image would
+    leave an undo that puts that single object back into the emptied mask --
+    resurrecting one member of a set the user deliberately cleared.
+    """
+    mask = world["mask"]
+    doomed_id = _add(session, mask).id
+    _add(session, mask, cx=500, cy=500)
+    _delete_with_history(session, mask, doomed_id)
+    assert history_db.get_status(mask.id, ANNOTATOR, session)["can_undo"] is True
+
+    asyncio.run(masks_db.delete_all_contours_of_mask(mask.id, db=session))
+
+    assert history_db.get_status(mask.id, ANNOTATOR, session)["can_undo"] is False
+    assert _ids(session, mask) == set()
+    with pytest.raises(history_db.HistoryError):
+        history_db.undo(mask.id, ANNOTATOR, session)
+
+
+def test_wiping_a_mask_discards_every_annotators_history(session, world):
+    """The wipe is mask-wide, so it must not leave one user's stack behind."""
+    mask = world["mask"]
+    mine = _add(session, mask).id
+    theirs = _add(session, mask, cx=500, cy=500).id
+    _delete_with_history(session, mask, mine, username=ANNOTATOR)
+    _delete_with_history(session, mask, theirs, username=OTHER)
+
+    asyncio.run(masks_db.delete_all_contours_of_mask(mask.id, db=session))
+
+    assert session.query(AnnotationActions).filter_by(mask_id=mask.id).count() == 0


### PR DESCRIPTION
- Added new endpoints for managing annotation history (undo/redo) in `annotation_history.py`.
- Integrated history recording into contour modification and deletion processes in `contours.py`.
- Enhanced WebSocket handlers to support history recording for object modifications and deletions in `annotation_handlers.py`.
- Created a new service for managing annotation history in `annotation_history.py`, including methods for recording actions and applying undo/redo.
- Updated the masks service to clear history when all contours are deleted.
- Developed comprehensive tests for the annotation history functionality, ensuring correct behavior for undoing and redoing actions, as well as maintaining stack semantics.