### PR TITLE
Feat/instance training updates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,9 @@ pip-delete-this-directory.txt
 *.cfg
 
 # Data Files
+app.db
+mlflow.db
+mlruns/
 sam_vit_b_01ec64.pth
 data/*
 !data/.gitkeep

--- a/app/routes/services/instance_seg_router.py
+++ b/app/routes/services/instance_seg_router.py
@@ -188,7 +188,11 @@ async def start_training(
     )
 
     try:
-        result = await service.start_training(request, model_run_name=body.model_run_name)
+        result = await service.start_training(
+            request,
+            model_run_name=body.model_run_name,
+            dataset_name=dataset.name,
+        )
     except Exception as exc:
         logger.exception("Failed to start instance segmentation training.")
         raise HTTPException(status_code=http_status.HTTP_502_BAD_GATEWAY,

--- a/app/routes/services/instance_seg_router.py
+++ b/app/routes/services/instance_seg_router.py
@@ -38,22 +38,116 @@ DEFAULT_MODEL_REGISTRY_KEY = "mask2former"
 # its MLflow run.
 TRAINING_EXPERIMENT = "instance-segmentation-training"
 
-# Map MLflow run statuses to the coarse state the frontend renders.
-_STATE_BY_MLFLOW_STATUS = {
+# Canonical-to-public lifecycle state mapping.
+_CANONICAL_TO_PUBLIC_STATE = {
+    "starting": "STARTING",
+    "running": "PROGRESS",
+    "completed": "SUCCESS",
+    "failed": "FAILED",
+    "cancelled": "CANCELLED",
+    "timed_out": "TIMED_OUT",
+}
+
+# Legacy MLflow status fallback mapping when training_state tag is absent.
+_LEGACY_MLFLOW_STATUS_TO_PUBLIC_STATE = {
+    "RUNNING": "PROGRESS",
     "FINISHED": "SUCCESS",
     "FAILED": "FAILED",
     "KILLED": "CANCELLED",
 }
 
-_MLFLOW_STATUS_BY_CELERY_STATE = {
-    "SUCCESS": "FINISHED",
-    "FAILURE": "FAILED",
-    "REVOKED": "KILLED",
-}
-_TERMINAL_STATES = {"SUCCESS", "FAILED", "CANCELLED"}
+_TERMINAL_STATES = {"SUCCESS", "FAILED", "CANCELLED", "TIMED_OUT"}
 _VALIDATION_METRIC_PATTERN = re.compile(
     r"^val_mask_(iou|f1|precision|recall)_label_(\d+)$"
 )
+
+
+def _parse_timestamp(raw_value) -> float | None:
+    """Safely parse optional numeric queue timestamps (e.g. Unix seconds)."""
+    if raw_value is None:
+        return None
+    try:
+        return float(raw_value)
+    except (ValueError, TypeError):
+        return None
+
+
+def _map_training_state_to_public_state(
+    training_state: Optional[str], mlflow_status: Optional[str] = None
+) -> str:
+    """Map canonical/durable training state to public state with legacy MLflow fallback."""
+    canonical = str(training_state).lower().strip() if training_state else None
+
+    # If MLflow status is terminal (FINISHED, FAILED, KILLED) but the training_state tag is still
+    # non-terminal (starting, running), the terminal MLflow status takes precedence over the stale tag.
+    if mlflow_status in _LEGACY_MLFLOW_STATUS_TO_PUBLIC_STATE and mlflow_status != "RUNNING":
+        legacy_state = _LEGACY_MLFLOW_STATUS_TO_PUBLIC_STATE[mlflow_status]
+        if (
+            canonical not in _CANONICAL_TO_PUBLIC_STATE
+            or _CANONICAL_TO_PUBLIC_STATE[canonical] not in _TERMINAL_STATES
+        ):
+            return legacy_state
+
+    if canonical and canonical in _CANONICAL_TO_PUBLIC_STATE:
+        return _CANONICAL_TO_PUBLIC_STATE[canonical]
+    if mlflow_status:
+        return _LEGACY_MLFLOW_STATUS_TO_PUBLIC_STATE.get(mlflow_status, "PROGRESS")
+    return "STARTING"
+
+
+
+def _empty_snapshot(task_id: str, ai_status: Optional[dict] = None) -> dict:
+    """Build an initial/fallback snapshot when no MLflow run exists yet."""
+    ai_status = ai_status or {}
+    raw_training_state = ai_status.get("training_state")
+    celery_or_effective_state = ai_status.get("state")
+
+    if raw_training_state:
+        training_state = str(raw_training_state).lower().strip()
+        state = _map_training_state_to_public_state(training_state)
+    elif celery_or_effective_state == "REVOKED":
+        state = "CANCELLED"
+        training_state = "cancelled"
+    elif celery_or_effective_state == "FAILURE":
+        state = "FAILED"
+        training_state = "failed"
+    elif celery_or_effective_state == "SUCCESS":
+        state = "SUCCESS"
+        training_state = "completed"
+    else:
+        state = "STARTING"
+        training_state = "starting"
+
+    mlflow_status = None
+    if state in {"CANCELLED", "TIMED_OUT"}:
+        mlflow_status = "KILLED"
+    elif state == "FAILED":
+        mlflow_status = "FAILED"
+    elif state == "SUCCESS":
+        mlflow_status = "FINISHED"
+
+    return {
+        "task_id": task_id,
+        "run_id": ai_status.get("run_id"),
+        "state": state,
+        "training_state": training_state,
+        "message": ai_status.get("message"),
+        "queued_at": _parse_timestamp(ai_status.get("queued_at")),
+        "start_deadline": _parse_timestamp(ai_status.get("start_deadline")),
+        "started_at": ai_status.get("started_at"),
+        "mlflow_status": mlflow_status,
+        "epoch": 0,
+        "total_epochs": None,
+        "training_parameters": {},
+        "loss": [],
+        "validation_metrics": None,
+        "validation_metrics_unavailable": None,
+        "label_ids": [],
+        "run_name": None,
+        "start_time": None,
+        "end_time": None,
+    }
+
 
 
 class StartTrainingBody(BaseModel):
@@ -280,51 +374,96 @@ def _validation_metrics_from_run(run) -> dict | None:
     }
 
 
-def _snapshot_from_run(client, run, task_id: Optional[str] = None) -> dict:
+def _snapshot_from_run(
+    client, run, task_id: Optional[str] = None, ai_status: Optional[dict] = None
+) -> dict:
     """Build a progress snapshot dict from an MLflow run."""
     run_id = run.info.run_id
     mlflow_status = run.info.status
-    state = _STATE_BY_MLFLOW_STATUS.get(mlflow_status, "PROGRESS")
+    tags = getattr(run.data, "tags", {}) or {}
+    ai_status = ai_status or {}
 
-    try:
-        loss_history = client.get_metric_history(run_id, "loss")
-    except Exception:
-        loss_history = []
-    loss = [{"epoch": int(m.step), "value": m.value}
-            for m in sorted(loss_history, key=lambda m: m.step)]
+    raw_training_state = tags.get("training_state") or ai_status.get("training_state")
+    training_state = (
+        str(raw_training_state).lower().strip() if raw_training_state else None
+    )
+    state = _map_training_state_to_public_state(training_state, mlflow_status)
 
-    total_epochs = run.data.params.get("epochs")
+    loss_history = []
+    if client is not None:
+        try:
+            loss_history = client.get_metric_history(run_id, "loss")
+        except Exception:
+            loss_history = []
+    loss = [
+        {"epoch": int(m.step), "value": m.value}
+        for m in sorted(loss_history, key=lambda m: m.step)
+    ]
+
+    params = getattr(run.data, "params", {}) or {}
+    total_epochs = params.get("epochs")
     total_epochs = int(total_epochs) if total_epochs is not None else None
     training_parameters = {
         key: value
-        for key, value in run.data.params.items()
+        for key, value in params.items()
         if key not in {"dataset_id", "selected_database_label_ids"}
     }
 
-    epoch_metric = run.data.metrics.get("epoch")
+    metrics = getattr(run.data, "metrics", {}) or {}
+    epoch_metric = metrics.get("epoch")
     epoch = int(epoch_metric) if epoch_metric is not None else (loss[-1]["epoch"] if loss else 0)
     validation_metrics = _validation_metrics_from_run(run)
 
+    message = (
+        tags.get("status_message")
+        or tags.get("message")
+        or ai_status.get("message")
+    )
+    queued_at = _parse_timestamp(
+        tags.get("queued_at") or ai_status.get("queued_at")
+    )
+    start_deadline = _parse_timestamp(
+        tags.get("start_deadline") or ai_status.get("start_deadline")
+    )
+    started_at = (
+        tags.get("started_at")
+        or ai_status.get("started_at")
+    )
+
+    resolved_task_id = task_id if task_id is not None else tags.get("celery_task_id")
+
     return {
-        "task_id": task_id if task_id is not None else run.data.tags.get("celery_task_id"),
+        "task_id": resolved_task_id,
         "run_id": run_id,
         "state": state,
+        "training_state": training_state,
+        "message": message,
+        "queued_at": queued_at,
+        "start_deadline": start_deadline,
+        "started_at": started_at,
         "mlflow_status": mlflow_status,
         "epoch": epoch,
         "total_epochs": total_epochs,
         "training_parameters": training_parameters,
         "loss": loss,
         "validation_metrics": validation_metrics,
-        "validation_metrics_unavailable": run.data.tags.get("validation_metrics_unavailable"),
-        "label_ids": _parse_label_ids(run.data.tags.get("label_ids")),
-        "run_name": run.data.tags.get("run_name"),  # user-supplied alias; None when not set
+        "validation_metrics_unavailable": tags.get("validation_metrics_unavailable"),
+        "label_ids": _parse_label_ids(tags.get("label_ids")),
+        "run_name": tags.get("run_name"),  # user-supplied alias; None when not set
         "start_time": run.info.start_time,
         "end_time": run.info.end_time,
     }
 
 
-def _set_run_terminated(client, run_id: str, mlflow_status: str):
-    """Set a verified terminal MLflow state and return the fresh run record."""
+def _set_run_terminated(
+    client, run_id: str, mlflow_status: str, training_state: Optional[str] = None
+):
+    """Set a verified terminal MLflow state and optional tag, and return the fresh run record."""
+    if training_state:
+        try:
+            client.set_tag(run_id, "training_state", training_state)
+        except Exception:
+            pass
     client.set_terminated(run_id, status=mlflow_status)
     return client.get_run(run_id)
 
@@ -340,45 +479,79 @@ async def _reconcile_run_with_celery(run):
     if run.info.status != "RUNNING":
         return run
 
-    task_id = run.data.tags.get("celery_task_id")
+    tags = getattr(run.data, "tags", {}) or {}
+    task_id = tags.get("celery_task_id")
     if not task_id:
         return run
 
     try:
-        celery_state = await service.get_training_task_state(task_id)
+        ai_status = await service.get_training_task_status(task_id)
     except Exception:
-        logger.warning("Could not read Celery state for training task %s.", task_id)
+        logger.warning("Could not read Celery/AI state for training task %s.", task_id)
         return run
 
-    mlflow_status = _MLFLOW_STATUS_BY_CELERY_STATE.get(celery_state)
-    if mlflow_status is None:
+    # If the AI call updated shared MLflow tags, refetch the run before creating the snapshot
+    try:
+        refreshed_run = await asyncio.to_thread(MODEL_REGISTRY.client.get_run, run.info.run_id)
+        if refreshed_run is not None:
+            run = refreshed_run
+    except Exception:
+        pass
+
+    if run.info.status != "RUNNING":
+        return run
+
+    training_state = (ai_status.get("training_state") or "").lower().strip()
+    celery_state = ai_status.get("state")
+
+    target_mlflow_status = None
+    target_training_state = None
+    if training_state == "completed" or celery_state == "SUCCESS":
+        target_mlflow_status = "FINISHED"
+        target_training_state = "completed"
+    elif training_state == "failed" or celery_state == "FAILURE":
+        target_mlflow_status = "FAILED"
+        target_training_state = "failed"
+    elif training_state in {"cancelled", "timed_out"} or celery_state == "REVOKED":
+        target_mlflow_status = "KILLED"
+        target_training_state = "timed_out" if training_state == "timed_out" else "cancelled"
+
+    if target_mlflow_status is None:
         return run
 
     return await asyncio.to_thread(
-        _set_run_terminated, MODEL_REGISTRY.client, run.info.run_id, mlflow_status
+        _set_run_terminated,
+        MODEL_REGISTRY.client,
+        run.info.run_id,
+        target_mlflow_status,
+        target_training_state,
     )
+
 
 
 async def _read_training_snapshot(task_id: str) -> dict:
     """Read a progress snapshot for a Celery ``task_id`` straight from MLflow.
 
-    Returns a ``"starting"`` snapshot while no run exists yet (task queued but not
-    picked up by a worker).
+    Returns an initial snapshot while no MLflow run exists yet.
     """
     run = await asyncio.to_thread(_find_training_run, task_id)
     if run is None:
+        ai_status = None
         try:
-            celery_state = await service.get_training_task_state(task_id)
+            ai_status = await service.get_training_task_status(task_id)
         except Exception:
-            celery_state = None
-        if celery_state == "REVOKED":
-            return {"task_id": task_id, "run_id": None, "state": "CANCELLED", "mlflow_status": "KILLED",
-                    "epoch": 0, "total_epochs": None, "loss": [], "label_ids": []}
-        if celery_state == "FAILURE":
-            return {"task_id": task_id, "run_id": None, "state": "FAILED", "mlflow_status": "FAILED",
-                    "epoch": 0, "total_epochs": None, "loss": [], "label_ids": []}
-        return {"task_id": task_id, "run_id": None, "state": "starting", "mlflow_status": None,
-                "epoch": 0, "total_epochs": None, "loss": [], "label_ids": []}
+            logger.warning("Could not read training task status from AI service for task %s.", task_id)
+            ai_status = None
+
+        if ai_status and ai_status.get("run_id"):
+            try:
+                run = await asyncio.to_thread(MODEL_REGISTRY.client.get_run, ai_status["run_id"])
+            except Exception:
+                run = None
+
+        if run is None:
+            return _empty_snapshot(task_id, ai_status)
+
     run = await _reconcile_run_with_celery(run)
     return await asyncio.to_thread(_snapshot_from_run, MODEL_REGISTRY.client, run, task_id)
 
@@ -442,7 +615,7 @@ async def get_training_status_stream(task_id: str, request: Request,
     """Stream MLflow-backed progress for a training job as Server-Sent Events.
 
     Polls the MLflow run every couple of seconds and emits one ``data:`` event per
-    tick until the run reaches a terminal state (FINISHED/FAILED/KILLED).
+    tick until the run reaches a terminal state (SUCCESS/FAILED/CANCELLED/TIMED_OUT).
     """
 
     async def event_generator():
@@ -465,21 +638,43 @@ async def get_training_status_stream(task_id: str, request: Request,
 @router.delete("/training/{task_id}")
 async def cancel_training_of_model(task_id: str, user: User = Depends(get_current_user)):
     """Cancel a task and close its matching MLflow run as cancelled."""
+    ai_status = None
     try:
-        await service.cancel_training(task_id)
+        ai_status = await service.cancel_training(task_id)
+    except Exception as cancel_exc:
+        # Check if the task/run is already terminal before failing
         run = await asyncio.to_thread(_find_training_run, task_id)
-        if run is not None and run.info.status == "RUNNING":
-            run = await asyncio.to_thread(
-                _set_run_terminated, MODEL_REGISTRY.client, run.info.run_id, "KILLED"
+        if run is not None and run.info.status in {"FINISHED", "FAILED", "KILLED"}:
+            return await asyncio.to_thread(
+                _snapshot_from_run, MODEL_REGISTRY.client, run, task_id
             )
-        if run is None:
-            return {"task_id": task_id, "run_id": None, "state": "CANCELLED", "mlflow_status": "KILLED",
-                    "epoch": 0, "total_epochs": None, "loss": [], "label_ids": []}
-        return await asyncio.to_thread(_snapshot_from_run, MODEL_REGISTRY.client, run, task_id)
-    except Exception as exc:
-        logger.exception("Failed to cancel instance segmentation training.")
-        raise HTTPException(status_code=http_status.HTTP_502_BAD_GATEWAY,
-                            detail=f"Could not cancel training: {exc}")
+
+        logger.exception(
+            "Failed to cancel instance segmentation training on AI service for %s.", task_id
+        )
+        raise HTTPException(
+            status_code=http_status.HTTP_502_BAD_GATEWAY,
+            detail=f"Could not cancel training: {cancel_exc}",
+        )
+
+    run = await asyncio.to_thread(_find_training_run, task_id)
+    if run is not None and run.info.status == "RUNNING":
+        run = await asyncio.to_thread(
+            _set_run_terminated, MODEL_REGISTRY.client, run.info.run_id, "KILLED", "cancelled"
+        )
+
+    if run is None:
+        cancel_payload = ai_status or {
+            "training_state": "cancelled",
+            "state": "REVOKED",
+            "message": "Training cancelled by user.",
+        }
+        return _empty_snapshot(task_id, cancel_payload)
+    return await asyncio.to_thread(
+        _snapshot_from_run, MODEL_REGISTRY.client, run, task_id, ai_status
+    )
+
+
 
 
 # The POST /run inference endpoint was removed: nothing called it, and its request

--- a/app/routes/services/instance_seg_router.py
+++ b/app/routes/services/instance_seg_router.py
@@ -1,6 +1,7 @@
 import asyncio
 import json
 import os
+import re
 from logging import getLogger
 from typing import Optional
 
@@ -50,6 +51,9 @@ _MLFLOW_STATUS_BY_CELERY_STATE = {
     "REVOKED": "KILLED",
 }
 _TERMINAL_STATES = {"SUCCESS", "FAILED", "CANCELLED"}
+_VALIDATION_METRIC_PATTERN = re.compile(
+    r"^val_mask_(iou|f1|precision|recall)_label_(\d+)$"
+)
 
 
 class StartTrainingBody(BaseModel):
@@ -226,6 +230,52 @@ def _parse_label_ids(raw) -> list[int]:
         return []
 
 
+def _validation_metrics_from_run(run) -> dict | None:
+    """Expose final held-out quality metrics in a UI-friendly shape."""
+    per_label: dict[int, dict[str, float | int]] = {}
+    for metric_name, value in run.data.metrics.items():
+        match = _VALIDATION_METRIC_PATTERN.fullmatch(metric_name)
+        if match is None:
+            continue
+        metric, raw_label_id = match.groups()
+        label_id = int(raw_label_id)
+        per_label.setdefault(label_id, {"label_id": label_id})[metric] = float(value)
+
+    macro_iou = run.data.metrics.get("val_mask_iou_macro")
+    macro_f1 = run.data.metrics.get("val_mask_f1_macro")
+    macro_precision = run.data.metrics.get("val_mask_precision_macro")
+    macro_recall = run.data.metrics.get("val_mask_recall_macro")
+    ap = run.data.metrics.get("val_mask_ap")
+    ap50 = run.data.metrics.get("val_mask_ap50")
+    ap75 = run.data.metrics.get("val_mask_ap75")
+    if not per_label and all(
+        metric is None
+        for metric in (
+            macro_iou,
+            macro_f1,
+            macro_precision,
+            macro_recall,
+            ap,
+            ap50,
+            ap75,
+        )
+    ):
+        return None
+
+    return {
+        "ap": float(ap) if ap is not None else None,
+        "ap50": float(ap50) if ap50 is not None else None,
+        "ap75": float(ap75) if ap75 is not None else None,
+        "macro_iou": float(macro_iou) if macro_iou is not None else None,
+        "macro_f1": float(macro_f1) if macro_f1 is not None else None,
+        "macro_precision": (
+            float(macro_precision) if macro_precision is not None else None
+        ),
+        "macro_recall": float(macro_recall) if macro_recall is not None else None,
+        "per_label": [per_label[label_id] for label_id in sorted(per_label)],
+    }
+
+
 def _snapshot_from_run(client, run, task_id: Optional[str] = None) -> dict:
     """Build a progress snapshot dict from an MLflow run."""
     run_id = run.info.run_id
@@ -249,6 +299,7 @@ def _snapshot_from_run(client, run, task_id: Optional[str] = None) -> dict:
 
     epoch_metric = run.data.metrics.get("epoch")
     epoch = int(epoch_metric) if epoch_metric is not None else (loss[-1]["epoch"] if loss else 0)
+    validation_metrics = _validation_metrics_from_run(run)
 
     return {
         "task_id": task_id if task_id is not None else run.data.tags.get("celery_task_id"),
@@ -259,6 +310,8 @@ def _snapshot_from_run(client, run, task_id: Optional[str] = None) -> dict:
         "total_epochs": total_epochs,
         "training_parameters": training_parameters,
         "loss": loss,
+        "validation_metrics": validation_metrics,
+        "validation_metrics_unavailable": run.data.tags.get("validation_metrics_unavailable"),
         "label_ids": _parse_label_ids(run.data.tags.get("label_ids")),
         "run_name": run.data.tags.get("run_name"),  # user-supplied alias; None when not set
         "start_time": run.info.start_time,

--- a/app/routes/websockets/annotation_handlers.py
+++ b/app/routes/websockets/annotation_handlers.py
@@ -9,6 +9,7 @@ service modules (for persistence), and sends a ``ServerMessage`` back to the cli
 from logging import getLogger
 
 from fastapi.websockets import WebSocket
+from iquana_toolbox.inference import nms
 from iquana_toolbox.schemas.database.contours import Contour
 from iquana_toolbox.schemas.networking.websockets.annotation_session import (
     ServerMessageType,
@@ -632,10 +633,22 @@ async def handle_instance_segmentation(websocket: WebSocket, client_msg: ClientM
                                        state: AnnotationSessionState):
     """ Handle instance segmentation inference.
 
-        Instance segmentation re-segments the whole image, so the detected instances
-        replace every contour currently on the mask (the client warns the user about
-        this before requesting it).
+        ``override`` re-segments the whole image and replaces every contour currently on
+        the mask. ``patch`` keeps existing contours and adds only non-overlapping model
+        predictions. Omitted ``write_mode`` remains the destructive override behavior.
     """
+    message_data = client_msg.data or {}
+    write_mode = message_data.get("write_mode", "override")
+    if write_mode not in {"patch", "override"}:
+        await send_msg(websocket, ServerMessage(
+            id=client_msg.id,
+            type=ServerMessageType.ERROR,
+            success=False,
+            message="write_mode must be either 'patch' or 'override'.",
+            data=None,
+        ))
+        return
+
     if Backends.INSTANCE_SEGMENTATION.value not in state._running_backends:
         await send_msg(websocket, ServerMessage(
             id=client_msg.id,
@@ -646,7 +659,7 @@ async def handle_instance_segmentation(websocket: WebSocket, client_msg: ClientM
         ))
         return
 
-    model_registry_key = client_msg.data.get("model_registry_key")
+    model_registry_key = message_data.get("model_registry_key")
     result = await run_instance_segmentation(
         service=state._running_backends[Backends.INSTANCE_SEGMENTATION.value],
         image_url=state.image_db.file_path,
@@ -656,11 +669,30 @@ async def handle_instance_segmentation(websocket: WebSocket, client_msg: ClientM
         user_id=state.user_id,
     )
 
-    # Replace the existing contours with the freshly detected instances.
+    contours_to_add = result.contours
+    suppressed_count = 0
     with get_context_session() as db:
-        await masks_db.delete_all_contours_of_mask(state.mask_id, db=db)
-        for contour in result.contours:
-            await masks_db.add_contour_to_mask(state.mask_id, contour, db=db)
+        if write_mode == "patch":
+            existing_hierarchy = await masks_db.get_contour_hierarchy_of_mask(state.mask_id, db)
+            existing_contours = list(existing_hierarchy.id_to_contour.values())
+            nms_result = nms(result.contours, existing=existing_contours)
+            contours_to_add = [result.contours[index] for index in nms_result.kept]
+            suppressed_count = len(nms_result.suppressed)
+        else:
+            # Preserve the established destructive behavior for override and for
+            # clients that omit write_mode.
+            await masks_db.delete_all_contours_of_mask(state.mask_id, db=db)
+
+        for contour in contours_to_add:
+            await masks_db.add_contour_to_mask(
+                state.mask_id,
+                contour,
+                db=db,
+                # Instance models currently return a flat list. Patch writes must
+                # preserve that geometry and must not infer a hierarchy.
+                check_hierarchy=write_mode == "override",
+                author_username=state.user_id,
+            )
         hierarchy, payload = await masks_db.get_cached_contour_hierarchy_of_mask(state.mask_id, db)
     state.contour_hierarchy = hierarchy
 
@@ -672,8 +704,12 @@ async def handle_instance_segmentation(websocket: WebSocket, client_msg: ClientM
         id=client_msg.id,
         type=ServerMessageType.OBJECTS,
         success=result.success,
-        message=result.message or f"Instance segmentation detected {len(result.contours)} objects.",
-        data=payload,
+        message=result.message or f"Instance segmentation detected {len(contours_to_add)} objects.",
+        data={
+            **payload,
+            "added_count": len(contours_to_add),
+            "suppressed_count": suppressed_count,
+        },
     ))
 
 

--- a/app/services/ai_services/instance_segmentation.py
+++ b/app/services/ai_services/instance_segmentation.py
@@ -35,6 +35,7 @@ class InstanceSegmentationService(BaseService):
         self,
         request: InstanceSegmentationTrainingRequest,
         model_run_name: str | None = None,
+        dataset_name: str | None = None,
     ) -> dict:
         """Dispatch a training job to the instance-segmentation service.
 
@@ -48,10 +49,14 @@ class InstanceSegmentationService(BaseService):
                 MLflow tag (e.g. ``"Cells-FineTuned-v1"``).  Passed as a query
                 parameter so the shared ``InstanceSegmentationTrainingRequest`` schema
                 in ``iquana_toolbox`` does not need to change.
+            dataset_name: Optional snapshot of the dataset's human-readable name,
+                also passed as a query parameter for model provenance metadata.
         """
         params = {}
         if model_run_name:
             params["model_run_name"] = model_run_name
+        if dataset_name:
+            params["dataset_name"] = dataset_name
         async with httpx.AsyncClient(timeout=120) as client:
             url = f"{self.backend_url}/train"
             response = await client.post(url, json=request.model_dump(), params=params)

--- a/app/services/ai_services/instance_segmentation.py
+++ b/app/services/ai_services/instance_segmentation.py
@@ -71,10 +71,18 @@ class InstanceSegmentationService(BaseService):
             response.raise_for_status()
             return response.json()
 
-    async def get_training_task_state(self, task_id: str) -> str:
-        """Read the authoritative Celery state for a training task."""
+    async def get_training_task_status(self, task_id: str) -> dict:
+        """Read the full training lifecycle status from the instance-segmentation service."""
         async with httpx.AsyncClient(timeout=10) as client:
             url = f"{self.backend_url}/train/{task_id}"
             response = await client.get(url)
             response.raise_for_status()
-            return response.json().get("state", "PENDING")
+            return response.json()
+
+    async def get_training_task_state(self, task_id: str) -> str:
+        """Read the authoritative Celery state for a training task.
+
+        Compatibility wrapper returning the coarse Celery state.
+        """
+        payload = await self.get_training_task_status(task_id)
+        return payload.get("state", "PENDING")

--- a/app/services/model_registry.py
+++ b/app/services/model_registry.py
@@ -4,17 +4,112 @@ The backend reads available models straight from the shared MLflow registry
 instead of HTTP-hopping through each AI service's ``/models`` endpoint. MLflow
 is the source of truth, so this removes one network round-trip per request.
 """
+import json
 from logging import getLogger
 
 import mlflow
 from iquana_toolbox.mlflow import MLFlowModelRegistry
 
+from app.database import get_context_session
+from app.database.datasets import Datasets
+from app.database.labels import Labels
 from config import MLFLOW_URL
 
 logger = getLogger(__name__)
 
 # Client only; no connection is made until a query runs.
 MODEL_REGISTRY = MLFlowModelRegistry(MLFLOW_URL)
+
+
+def _model_tag_value(model_info: dict, key: str):
+    tags = model_info.get("tags")
+    if isinstance(tags, dict):
+        return tags.get(key)
+    if isinstance(tags, list):
+        for tag in tags:
+            if isinstance(tag, dict) and tag.get("key") == key:
+                return tag.get("value")
+    return None
+
+
+def _parse_id_list(value) -> list[int]:
+    if isinstance(value, str):
+        try:
+            value = json.loads(value)
+        except json.JSONDecodeError:
+            value = value.split(",")
+    if not isinstance(value, (list, tuple)):
+        return []
+
+    ids = []
+    for item in value:
+        try:
+            ids.append(int(item))
+        except (TypeError, ValueError):
+            continue
+    return ids
+
+
+def _set_model_tag(model_info: dict, key: str, value: str):
+    tags = model_info.get("tags")
+    if isinstance(tags, dict):
+        tags[key] = value
+        return
+    if isinstance(tags, list):
+        for tag in tags:
+            if isinstance(tag, dict) and tag.get("key") == key:
+                tag["value"] = value
+                return
+        tags.append({"key": key, "value": value})
+        return
+    model_info["tags"] = {key: value}
+
+
+def _enrich_model_provenance(model_info: dict) -> dict:
+    """Add names for legacy trained models that only stored database IDs."""
+    dataset_id_value = (
+        _model_tag_value(model_info, "trained_on_dataset_id")
+        or _model_tag_value(model_info, "dataset_id")
+        or model_info.get("dataset_id")
+    )
+    try:
+        dataset_id = int(dataset_id_value)
+    except (TypeError, ValueError):
+        return model_info
+
+    label_ids = _parse_id_list(model_info.get("label_ids"))
+    if not label_ids:
+        label_ids = _parse_id_list(_model_tag_value(model_info, "selected_label_ids"))
+
+    needs_dataset_name = not _model_tag_value(model_info, "trained_on_dataset_name")
+    needs_label_names = bool(label_ids) and not _model_tag_value(model_info, "trained_label_names")
+    if not needs_dataset_name and not needs_label_names:
+        return model_info
+
+    try:
+        with get_context_session() as db:
+            dataset = db.query(Datasets).filter(Datasets.id == dataset_id).first()
+            if dataset and needs_dataset_name:
+                _set_model_tag(model_info, "trained_on_dataset_id", str(dataset.id))
+                _set_model_tag(model_info, "trained_on_dataset_name", dataset.name)
+
+            if dataset and needs_label_names:
+                labels = (
+                    db.query(Labels)
+                    .filter(Labels.dataset_id == dataset_id, Labels.id.in_(label_ids))
+                    .all()
+                )
+                names_by_id = {label.id: label.name for label in labels}
+                names = [names_by_id.get(label_id, "") for label_id in label_ids]
+                _set_model_tag(
+                    model_info,
+                    "trained_label_names",
+                    json.dumps(names, ensure_ascii=False),
+                )
+    except Exception:
+        logger.exception("Failed to resolve provenance for trained model metadata.")
+
+    return model_info
 
 
 def _search_registered_models_by_tags(tags: dict):
@@ -73,7 +168,15 @@ def _full_model_info(registry_key: str) -> dict:
     try:
         info = mlflow.models.get_model_info(f"models:/{registry_key}/latest")
         if info.metadata:
-            return info.metadata
+            metadata = dict(info.metadata)
+            if isinstance(metadata.get("tags"), dict):
+                metadata["tags"] = dict(metadata["tags"])
+            elif isinstance(metadata.get("tags"), list):
+                metadata["tags"] = [
+                    dict(tag) if isinstance(tag, dict) else tag
+                    for tag in metadata["tags"]
+                ]
+            return _enrich_model_provenance(metadata)
         logger.warning("Model '%s' has no artifact metadata; returning stub.", registry_key)
     except Exception:
         logger.exception("Failed to read artifact metadata for model '%s'.", registry_key)

--- a/app/services/model_registry.py
+++ b/app/services/model_registry.py
@@ -71,7 +71,7 @@ def _full_model_info(registry_key: str) -> dict:
     Falls back to a minimal stub if an older artifact carries no metadata.
     """
     try:
-        info = mlflow.models.get_model_info(f"models:/{registry_key}@latest")
+        info = mlflow.models.get_model_info(f"models:/{registry_key}/latest")
         if info.metadata:
             return info.metadata
         logger.warning("Model '%s' has no artifact metadata; returning stub.", registry_key)

--- a/tests/test_annotation_handlers.py
+++ b/tests/test_annotation_handlers.py
@@ -1,0 +1,152 @@
+"""Focused tests for interactive instance-segmentation write modes."""
+
+import asyncio
+from contextlib import contextmanager
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+from iquana_toolbox.schemas.database.contour_hierarchy import ContourHierarchy
+from iquana_toolbox.schemas.database.contours import Contour
+from iquana_toolbox.schemas.networking.websockets.annotation_session import ClientMessage
+
+from app.routes.websockets import annotation_handlers as handlers
+from app.services.annotation_session.operations import InstanceSegmentationResult
+from app.services.annotation_session.state import Backends
+
+
+def box(x0, y0, x1, y1, *, contour_id=None, confidence=1.0):
+    return Contour(
+        id=contour_id,
+        x=[x0, x1, x1, x0],
+        y=[y0, y0, y1, y1],
+        confidence=confidence,
+        added_by="model",
+    )
+
+
+def _setup(monkeypatch, *, write_mode=None, predictions=(), hierarchies=()):
+    state = SimpleNamespace(
+        _running_backends={Backends.INSTANCE_SEGMENTATION.value: object()},
+        image_db=SimpleNamespace(file_path="image.png", width=100, height=100),
+        user_id="alice",
+        mask_id=7,
+        contour_hierarchy=None,
+    )
+    data = {"model_registry_key": "model"}
+    if write_mode is not None:
+        data["write_mode"] = write_mode
+    client_msg = ClientMessage(id="request-1", type="instance_inference", data=data)
+    sent = []
+
+    async def send(_websocket, message):
+        sent.append(message)
+
+    monkeypatch.setattr(handlers, "send_msg", send)
+    monkeypatch.setattr(
+        handlers,
+        "run_instance_segmentation",
+        AsyncMock(return_value=InstanceSegmentationResult(
+            contours=list(predictions), success=True, message="model finished"
+        )),
+    )
+
+    db = object()
+
+    @contextmanager
+    def context_session():
+        yield db
+
+    monkeypatch.setattr(handlers, "get_context_session", context_session)
+
+    delete = AsyncMock()
+    add = AsyncMock()
+    hierarchy_queue = list(hierarchies)
+
+    async def get_hierarchy(_mask_id, _db):
+        return hierarchy_queue.pop(0)
+
+    async def get_cached_hierarchy(_mask_id, _db):
+        hierarchy = hierarchy_queue.pop(0)
+        return hierarchy, hierarchy.model_dump()
+
+    monkeypatch.setattr(handlers.masks_db, "delete_all_contours_of_mask", delete)
+    monkeypatch.setattr(handlers.masks_db, "add_contour_to_mask", add)
+    monkeypatch.setattr(handlers.masks_db, "get_contour_hierarchy_of_mask", get_hierarchy)
+    monkeypatch.setattr(handlers.masks_db, "get_cached_contour_hierarchy_of_mask", get_cached_hierarchy)
+
+    return state, client_msg, sent, delete, add
+
+
+def test_patch_preserves_existing_and_suppresses_overlaps(monkeypatch):
+    existing = box(0.0, 0.0, 0.3, 0.3, contour_id=1)
+    duplicate_existing = box(0.0, 0.0, 0.3, 0.3, confidence=0.9)
+    kept = box(0.5, 0.5, 0.7, 0.7, confidence=0.8)
+    duplicate_prediction = box(0.5, 0.5, 0.7, 0.7, confidence=0.1)
+    existing_hierarchy = ContourHierarchy(
+        root_contours=[existing], id_to_contour={1: existing}, label_id_to_contours={None: [existing]}
+    )
+    final_hierarchy = ContourHierarchy(root_contours=[existing, kept])
+    state, message, sent, delete, add = _setup(
+        monkeypatch,
+        write_mode="patch",
+        predictions=[duplicate_existing, kept, duplicate_prediction],
+        hierarchies=[existing_hierarchy, final_hierarchy],
+    )
+
+    asyncio.run(handlers.handle_instance_segmentation(object(), message, state))
+
+    delete.assert_not_awaited()
+    assert add.await_count == 1
+    assert add.await_args.kwargs["author_username"] == "alice"
+    assert add.await_args.kwargs["check_hierarchy"] is False
+    assert add.await_args.args[1] == kept
+    response = sent[-1]
+    assert response.type == "objects"
+    assert response.data["root_contours"]
+    assert response.data["added_count"] == 1
+    assert response.data["suppressed_count"] == 2
+
+
+def test_override_deletes_existing_contours_before_adding_predictions(monkeypatch):
+    predictions = [box(0.1, 0.1, 0.2, 0.2), box(0.5, 0.5, 0.6, 0.6)]
+    final_hierarchy = ContourHierarchy(root_contours=predictions)
+    state, message, sent, delete, add = _setup(
+        monkeypatch, write_mode="override", predictions=predictions, hierarchies=[final_hierarchy]
+    )
+
+    asyncio.run(handlers.handle_instance_segmentation(object(), message, state))
+
+    delete.assert_awaited_once()
+    assert delete.await_args.args == (7,)
+    assert add.await_count == 2
+    assert all(call.kwargs["author_username"] == "alice" for call in add.await_args_list)
+    assert all(call.kwargs["check_hierarchy"] is True for call in add.await_args_list)
+    assert sent[-1].data["added_count"] == 2
+    assert sent[-1].data["suppressed_count"] == 0
+
+
+def test_omitted_write_mode_keeps_destructive_override_compatibility(monkeypatch):
+    predictions = [box(0.1, 0.1, 0.2, 0.2)]
+    final_hierarchy = ContourHierarchy(root_contours=predictions)
+    state, message, _sent, delete, add = _setup(
+        monkeypatch, predictions=predictions, hierarchies=[final_hierarchy]
+    )
+
+    asyncio.run(handlers.handle_instance_segmentation(object(), message, state))
+
+    delete.assert_awaited_once()
+    assert add.await_count == 1
+    assert add.await_args.kwargs["check_hierarchy"] is True
+
+
+def test_invalid_write_mode_returns_error_without_inference_or_db_mutation(monkeypatch):
+    state, message, sent, delete, add = _setup(monkeypatch, write_mode="merge")
+
+    asyncio.run(handlers.handle_instance_segmentation(object(), message, state))
+
+    assert sent[-1].type == "error"
+    assert sent[-1].success is False
+    assert "write_mode" in sent[-1].message
+    handlers.run_instance_segmentation.assert_not_awaited()
+    delete.assert_not_awaited()
+    add.assert_not_awaited()

--- a/tests/test_instance_training_lifecycle.py
+++ b/tests/test_instance_training_lifecycle.py
@@ -1,0 +1,411 @@
+import asyncio
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from app.routes.services import instance_seg_router
+from app.routes.services.instance_seg_router import (
+    _CANONICAL_TO_PUBLIC_STATE,
+    _TERMINAL_STATES,
+    _empty_snapshot,
+    _map_training_state_to_public_state,
+    _parse_timestamp,
+    _read_training_snapshot,
+    _reconcile_run_with_celery,
+    _snapshot_from_run,
+)
+
+
+def _mock_run(
+    *,
+    run_id="run-1",
+    status="RUNNING",
+    tags=None,
+    params=None,
+    metrics=None,
+    start_time=1000,
+    end_time=2000,
+):
+    return SimpleNamespace(
+        info=SimpleNamespace(
+            run_id=run_id,
+            status=status,
+            start_time=start_time,
+            end_time=end_time,
+        ),
+        data=SimpleNamespace(
+            metrics=metrics or {},
+            params=params or {"epochs": "5", "batch_size": "2"},
+            tags={"celery_task_id": "task-1", **(tags or {})},
+        ),
+    )
+
+
+def test_starting_tag_maps_to_public_starting_and_is_non_terminal():
+    run = _mock_run(
+        status="RUNNING",
+        tags={"training_state": "starting", "queued_at": "1718000000.5"},
+    )
+    snapshot = _snapshot_from_run(None, run, "task-1")
+
+    assert snapshot["state"] == "STARTING"
+    assert snapshot["training_state"] == "starting"
+    assert snapshot["state"] not in _TERMINAL_STATES
+    assert snapshot["queued_at"] == 1718000000.5
+
+
+def test_running_tag_maps_to_public_progress_and_is_non_terminal():
+    run = _mock_run(
+        status="RUNNING",
+        tags={"training_state": "running", "started_at": "2026-08-18T10:00:00Z"},
+    )
+    snapshot = _snapshot_from_run(None, run, "task-1")
+
+    assert snapshot["state"] == "PROGRESS"
+    assert snapshot["training_state"] == "running"
+    assert snapshot["state"] not in _TERMINAL_STATES
+    assert snapshot["started_at"] == "2026-08-18T10:00:00Z"
+
+
+def test_completed_tag_maps_to_public_success_and_is_terminal():
+    run = _mock_run(
+        status="FINISHED",
+        tags={"training_state": "completed"},
+    )
+    snapshot = _snapshot_from_run(None, run, "task-1")
+
+    assert snapshot["state"] == "SUCCESS"
+    assert snapshot["training_state"] == "completed"
+    assert snapshot["state"] in _TERMINAL_STATES
+
+
+def test_failed_tag_maps_to_public_failed_and_preserves_message():
+    run = _mock_run(
+        status="FAILED",
+        tags={
+            "training_state": "failed",
+            "status_message": "CUDA out of memory during batch 4",
+        },
+    )
+    snapshot = _snapshot_from_run(None, run, "task-1")
+
+    assert snapshot["state"] == "FAILED"
+    assert snapshot["training_state"] == "failed"
+    assert snapshot["state"] in _TERMINAL_STATES
+    assert snapshot["message"] == "CUDA out of memory during batch 4"
+
+
+def test_cancelled_tag_maps_to_public_cancelled_and_preserves_message():
+    run = _mock_run(
+        status="KILLED",
+        tags={
+            "training_state": "cancelled",
+            "status_message": "Training cancelled by user.",
+        },
+    )
+    snapshot = _snapshot_from_run(None, run, "task-1")
+
+    assert snapshot["state"] == "CANCELLED"
+    assert snapshot["training_state"] == "cancelled"
+    assert snapshot["state"] in _TERMINAL_STATES
+    assert snapshot["message"] == "Training cancelled by user."
+
+
+def test_timed_out_tag_maps_to_public_timed_out_and_is_terminal():
+    run = _mock_run(
+        status="KILLED",
+        tags={
+            "training_state": "timed_out",
+            "status_message": "Training did not start before the queue deadline.",
+            "queued_at": "1718000000",
+            "start_deadline": "1718000300",
+        },
+    )
+    snapshot = _snapshot_from_run(None, run, "task-1")
+
+    assert snapshot["state"] == "TIMED_OUT"
+    assert snapshot["training_state"] == "timed_out"
+    assert snapshot["state"] in _TERMINAL_STATES
+    assert snapshot["message"] == "Training did not start before the queue deadline."
+    assert snapshot["queued_at"] == 1718000000.0
+    assert snapshot["start_deadline"] == 1718000300.0
+
+
+def test_all_queue_metadata_fields_are_exposed_in_snapshot():
+    run = _mock_run(
+        status="RUNNING",
+        tags={
+            "training_state": "starting",
+            "status_message": "Queued waiting for worker",
+            "queued_at": "1718000100.25",
+            "start_deadline": "1718000400.25",
+            "started_at": "2026-08-18T10:05:00Z",
+        },
+    )
+    snapshot = _snapshot_from_run(None, run, "task-1")
+
+    expected_keys = {
+        "task_id",
+        "run_id",
+        "state",
+        "training_state",
+        "message",
+        "queued_at",
+        "start_deadline",
+        "started_at",
+        "mlflow_status",
+        "epoch",
+        "total_epochs",
+        "training_parameters",
+        "loss",
+        "validation_metrics",
+        "validation_metrics_unavailable",
+        "label_ids",
+        "run_name",
+        "start_time",
+        "end_time",
+    }
+    assert set(snapshot.keys()) == expected_keys
+    assert snapshot["queued_at"] == 1718000100.25
+    assert snapshot["start_deadline"] == 1718000400.25
+    assert snapshot["started_at"] == "2026-08-18T10:05:00Z"
+    assert snapshot["message"] == "Queued waiting for worker"
+
+
+def test_legacy_untagged_runs_use_fallback_mapping():
+    running_run = _mock_run(status="RUNNING", tags={})
+    finished_run = _mock_run(status="FINISHED", tags={})
+    failed_run = _mock_run(status="FAILED", tags={})
+    killed_run = _mock_run(status="KILLED", tags={})
+
+    assert _snapshot_from_run(None, running_run)["state"] == "PROGRESS"
+    assert _snapshot_from_run(None, finished_run)["state"] == "SUCCESS"
+    assert _snapshot_from_run(None, failed_run)["state"] == "FAILED"
+    # Legacy KILLED maps to CANCELLED, never inferring TIMED_OUT without tag
+    assert _snapshot_from_run(None, killed_run)["state"] == "CANCELLED"
+
+
+def test_ai_status_check_that_changes_tags_refetches_run(monkeypatch):
+    initial_run = _mock_run(
+        run_id="run-100",
+        status="RUNNING",
+        tags={"celery_task_id": "task-100", "training_state": "starting"},
+    )
+    refreshed_run = _mock_run(
+        run_id="run-100",
+        status="KILLED",
+        tags={
+            "celery_task_id": "task-100",
+            "training_state": "timed_out",
+            "status_message": "Training did not start before the queue deadline.",
+        },
+    )
+
+    mock_get_status = AsyncMock(
+        return_value={
+            "task_id": "task-100",
+            "state": "REVOKED",
+            "training_state": "timed_out",
+            "message": "Training did not start before the queue deadline.",
+        }
+    )
+    monkeypatch.setattr(
+        instance_seg_router.service, "get_training_task_status", mock_get_status
+    )
+
+    mock_client = MagicMock()
+    mock_client.get_run.return_value = refreshed_run
+    monkeypatch.setattr(instance_seg_router.MODEL_REGISTRY, "client", mock_client)
+
+    result_run = asyncio.run(_reconcile_run_with_celery(initial_run))
+
+    assert result_run.info.status == "KILLED"
+    assert result_run.data.tags["training_state"] == "timed_out"
+    snapshot = _snapshot_from_run(None, result_run)
+    assert snapshot["state"] == "TIMED_OUT"
+    assert snapshot["message"] == "Training did not start before the queue deadline."
+
+
+def test_ai_status_unavailability_falls_back_without_false_terminal_result(
+    monkeypatch,
+):
+    active_run = _mock_run(
+        run_id="run-200",
+        status="RUNNING",
+        tags={"celery_task_id": "task-200", "training_state": "running"},
+    )
+
+    mock_get_status = AsyncMock(side_effect=Exception("AI Service connection timeout"))
+    monkeypatch.setattr(
+        instance_seg_router.service, "get_training_task_status", mock_get_status
+    )
+
+    result_run = asyncio.run(_reconcile_run_with_celery(active_run))
+
+    assert result_run.info.status == "RUNNING"
+    snapshot = _snapshot_from_run(None, result_run)
+    assert snapshot["state"] == "PROGRESS"
+    assert snapshot["state"] not in _TERMINAL_STATES
+
+
+def test_sse_emits_one_terminal_snapshot_and_then_stops(monkeypatch):
+    terminal_snapshot = {
+        "task_id": "task-300",
+        "run_id": "run-300",
+        "state": "TIMED_OUT",
+        "training_state": "timed_out",
+        "message": "Training did not start before the queue deadline.",
+    }
+
+    mock_read_snapshot = AsyncMock(return_value=terminal_snapshot)
+    monkeypatch.setattr(
+        instance_seg_router, "_read_training_snapshot", mock_read_snapshot
+    )
+
+    # Test the stream generator logic directly
+    async def run_stream():
+        mock_request = MagicMock()
+        mock_request.is_disconnected = AsyncMock(return_value=False)
+        response = await instance_seg_router.get_training_status_stream(
+            task_id="task-300", request=mock_request, user=None
+        )
+        events = []
+        async for chunk in response.body_iterator:
+            events.append(chunk)
+        return events
+
+    events = asyncio.run(run_stream())
+    assert len(events) == 1
+    assert "TIMED_OUT" in events[0]
+    assert mock_read_snapshot.call_count == 1
+
+
+def test_list_and_single_task_snapshots_have_the_same_lifecycle_fields():
+    run = _mock_run(
+        run_id="run-400",
+        status="RUNNING",
+        tags={
+            "celery_task_id": "task-400",
+            "training_state": "starting",
+            "queued_at": "1718000000",
+            "start_deadline": "1718000300",
+        },
+    )
+
+    run_snapshot = _snapshot_from_run(None, run, "task-400")
+    empty_snapshot = _empty_snapshot(
+        "task-400",
+        {
+            "training_state": "starting",
+            "queued_at": 1718000000.0,
+            "start_deadline": 1718000300.0,
+            "state": "PENDING",
+        },
+    )
+
+    assert set(run_snapshot.keys()) == set(empty_snapshot.keys())
+    assert empty_snapshot["state"] == "STARTING"
+    assert empty_snapshot["training_state"] == "starting"
+    assert empty_snapshot["queued_at"] == 1718000000.0
+    assert empty_snapshot["start_deadline"] == 1718000300.0
+
+
+def test_reconciliation_revoked_task_with_stale_running_tag_returns_cancelled(
+    monkeypatch,
+):
+    initial_run = _mock_run(
+        run_id="run-500",
+        status="RUNNING",
+        tags={"celery_task_id": "task-500", "training_state": "running"},
+    )
+    terminated_run = _mock_run(
+        run_id="run-500",
+        status="KILLED",
+        tags={"celery_task_id": "task-500", "training_state": "cancelled"},
+    )
+
+    mock_get_status = AsyncMock(
+        return_value={"task_id": "task-500", "state": "REVOKED"}
+    )
+    monkeypatch.setattr(
+        instance_seg_router.service, "get_training_task_status", mock_get_status
+    )
+
+    mock_client = MagicMock()
+    mock_client.get_run.side_effect = [initial_run, terminated_run]
+    monkeypatch.setattr(instance_seg_router.MODEL_REGISTRY, "client", mock_client)
+
+    result_run = asyncio.run(_reconcile_run_with_celery(initial_run))
+
+    mock_client.set_tag.assert_called_with("run-500", "training_state", "cancelled")
+    mock_client.set_terminated.assert_called_with("run-500", status="KILLED")
+    snapshot = _snapshot_from_run(None, result_run)
+    assert snapshot["state"] == "CANCELLED"
+    assert snapshot["state"] in _TERMINAL_STATES
+
+
+
+def test_terminal_mlflow_status_overrides_stale_running_tag():
+    run_killed = _mock_run(
+        status="KILLED",
+        tags={"training_state": "running"},
+    )
+    run_failed = _mock_run(
+        status="FAILED",
+        tags={"training_state": "running"},
+    )
+    run_finished = _mock_run(
+        status="FINISHED",
+        tags={"training_state": "starting"},
+    )
+
+    assert _snapshot_from_run(None, run_killed)["state"] == "CANCELLED"
+    assert _snapshot_from_run(None, run_failed)["state"] == "FAILED"
+    assert _snapshot_from_run(None, run_finished)["state"] == "SUCCESS"
+
+
+def test_cancel_training_error_does_not_mark_run_cancelled_locally(monkeypatch):
+    active_run = _mock_run(
+        run_id="run-600",
+        status="RUNNING",
+        tags={"celery_task_id": "task-600", "training_state": "running"},
+    )
+
+    mock_cancel = AsyncMock(side_effect=Exception("AI worker connection error"))
+    monkeypatch.setattr(instance_seg_router.service, "cancel_training", mock_cancel)
+
+    mock_find_run = MagicMock(return_value=active_run)
+    monkeypatch.setattr(instance_seg_router, "_find_training_run", mock_find_run)
+
+    mock_client = MagicMock()
+    monkeypatch.setattr(instance_seg_router.MODEL_REGISTRY, "client", mock_client)
+
+    with pytest.raises(instance_seg_router.HTTPException) as exc_info:
+        asyncio.run(
+            instance_seg_router.cancel_training_of_model(
+                task_id="task-600", user=None
+            )
+        )
+
+    assert exc_info.value.status_code == 502
+    assert "Could not cancel training" in exc_info.value.detail
+    mock_client.set_terminated.assert_not_called()
+
+
+def test_reconcile_run_with_celery_skips_non_running_historical_runs(monkeypatch):
+    finished_run = _mock_run(
+        run_id="run-700",
+        status="FINISHED",
+        tags={"celery_task_id": "task-700", "training_state": "completed"},
+    )
+
+    mock_get_status = AsyncMock()
+    monkeypatch.setattr(
+        instance_seg_router.service, "get_training_task_status", mock_get_status
+    )
+
+    result_run = asyncio.run(_reconcile_run_with_celery(finished_run))
+
+    assert result_run == finished_run
+    mock_get_status.assert_not_called()

--- a/tests/test_instance_training_metadata.py
+++ b/tests/test_instance_training_metadata.py
@@ -1,0 +1,61 @@
+import asyncio
+from iquana_toolbox.schemas.database.labels import Label
+from iquana_toolbox.schemas.training import InstanceSegmentationTrainingRequest
+
+from app.services.ai_services import instance_segmentation as instance_service
+
+
+class _Response:
+    def raise_for_status(self):
+        return None
+
+    def json(self):
+        return {"task_id": "task-1"}
+
+
+class _AsyncClient:
+    def __init__(self, observed):
+        self.observed = observed
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *_args):
+        return None
+
+    async def post(self, url, **kwargs):
+        self.observed.update(url=url, kwargs=kwargs)
+        return _Response()
+
+
+def test_start_training_forwards_dataset_name_as_query_metadata(monkeypatch):
+    observed = {}
+    monkeypatch.setattr(
+        instance_service.httpx,
+        "AsyncClient",
+        lambda **_kwargs: _AsyncClient(observed),
+    )
+    request = InstanceSegmentationTrainingRequest(
+        dataset_id=4,
+        image_folder_path="/tmp/images",
+        model_registry_key="mask2former",
+        user_id="trainer",
+        labels=[Label(id=5, dataset_id=4, name="cell", value=1)],
+        annotation_file_url="/tmp/annotations.json",
+        hyper_parameter={"epochs": 1},
+    )
+
+    result = asyncio.run(
+        instance_service.InstanceSegmentationService().start_training(
+            request,
+            model_run_name="custom model",
+            dataset_name="Cells dataset",
+        )
+    )
+
+    assert result == {"task_id": "task-1"}
+    assert observed["url"].endswith("/train")
+    assert observed["kwargs"]["params"] == {
+        "model_run_name": "custom model",
+        "dataset_name": "Cells dataset",
+    }

--- a/tests/test_instance_training_metadata.py
+++ b/tests/test_instance_training_metadata.py
@@ -59,3 +59,82 @@ def test_start_training_forwards_dataset_name_as_query_metadata(monkeypatch):
         "model_run_name": "custom model",
         "dataset_name": "Cells dataset",
     }
+
+
+class _StatusResponse:
+    def __init__(self, data):
+        self._data = data
+
+    def raise_for_status(self):
+        return None
+
+    def json(self):
+        return self._data
+
+
+class _StatusAsyncClient:
+    def __init__(self, observed, response_data):
+        self.observed = observed
+        self.response_data = response_data
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *_args):
+        return None
+
+    async def get(self, url, **kwargs):
+        self.observed.update(url=url, kwargs=kwargs)
+        return _StatusResponse(self.response_data)
+
+
+def test_get_training_task_status_preserves_full_lifecycle_payload(monkeypatch):
+    observed = {}
+    expected_payload = {
+        "task_id": "task-abc-123",
+        "state": "PENDING",
+        "training_state": "starting",
+        "run_id": "run-xyz-789",
+        "message": "Waiting for a GPU worker...",
+        "queued_at": 1718000000.0,
+        "start_deadline": 1718000300.0,
+        "started_at": "2026-08-18T12:00:00Z",
+    }
+
+    monkeypatch.setattr(
+        instance_service.httpx,
+        "AsyncClient",
+        lambda **_kwargs: _StatusAsyncClient(observed, expected_payload),
+    )
+
+    service = instance_service.InstanceSegmentationService()
+    result = asyncio.run(service.get_training_task_status("task-abc-123"))
+
+    assert result == expected_payload
+    assert result["training_state"] == "starting"
+    assert result["message"] == "Waiting for a GPU worker..."
+    assert result["queued_at"] == 1718000000.0
+    assert result["start_deadline"] == 1718000300.0
+    assert observed["url"].endswith("/train/task-abc-123")
+
+
+def test_get_training_task_state_compatibility_wrapper_returns_string(monkeypatch):
+    observed = {}
+    payload = {
+        "task_id": "task-abc-123",
+        "state": "SUCCESS",
+        "training_state": "completed",
+        "run_id": "run-xyz-789",
+    }
+
+    monkeypatch.setattr(
+        instance_service.httpx,
+        "AsyncClient",
+        lambda **_kwargs: _StatusAsyncClient(observed, payload),
+    )
+
+    service = instance_service.InstanceSegmentationService()
+    result = asyncio.run(service.get_training_task_state("task-abc-123"))
+
+    assert isinstance(result, str)
+    assert result == "SUCCESS"

--- a/tests/test_instance_training_metrics.py
+++ b/tests/test_instance_training_metrics.py
@@ -1,0 +1,101 @@
+from types import SimpleNamespace
+
+from app.routes.services.instance_seg_router import (
+    _snapshot_from_run,
+    _validation_metrics_from_run,
+)
+
+
+def _run(*, metrics, tags=None):
+    return SimpleNamespace(
+        info=SimpleNamespace(
+            run_id="run-1",
+            status="FINISHED",
+            start_time=1000,
+            end_time=2000,
+        ),
+        data=SimpleNamespace(
+            metrics=metrics,
+            params={"epochs": "3", "batch_size": "2"},
+            tags={"celery_task_id": "task-1", **(tags or {})},
+        ),
+    )
+
+
+def test_validation_metrics_are_grouped_by_label_and_macro_average():
+    run = _run(
+        metrics={
+            "loss": 0.25,
+            "val_mask_iou_label_42": 0.8,
+            "val_mask_f1_label_42": 0.88,
+            "val_mask_precision_label_42": 0.9,
+            "val_mask_recall_label_42": 0.86,
+            "val_mask_iou_label_7": 0.6,
+            "val_mask_f1_label_7": 0.75,
+            "val_mask_precision_label_7": 0.8,
+            "val_mask_recall_label_7": 0.7,
+            "val_mask_iou_macro": 0.7,
+            "val_mask_f1_macro": 0.815,
+            "val_mask_precision_macro": 0.85,
+            "val_mask_recall_macro": 0.78,
+        }
+    )
+
+    assert _validation_metrics_from_run(run) == {
+        "ap": None,
+        "ap50": None,
+        "ap75": None,
+        "macro_iou": 0.7,
+        "macro_f1": 0.815,
+        "macro_precision": 0.85,
+        "macro_recall": 0.78,
+        "per_label": [
+            {
+                "label_id": 7,
+                "iou": 0.6,
+                "f1": 0.75,
+                "precision": 0.8,
+                "recall": 0.7,
+            },
+            {
+                "label_id": 42,
+                "iou": 0.8,
+                "f1": 0.88,
+                "precision": 0.9,
+                "recall": 0.86,
+            },
+        ],
+    }
+
+
+def test_validation_metrics_expose_instance_average_precision_metrics():
+    run = _run(
+        metrics={
+            "val_mask_ap": 0.73,
+            "val_mask_ap50": 0.91,
+            "val_mask_ap75": 0.68,
+        }
+    )
+
+    assert _validation_metrics_from_run(run) == {
+        "ap": 0.73,
+        "ap50": 0.91,
+        "ap75": 0.68,
+        "macro_iou": None,
+        "macro_f1": None,
+        "macro_precision": None,
+        "macro_recall": None,
+        "per_label": [],
+    }
+
+
+def test_snapshot_keeps_validation_unavailable_reason():
+    run = _run(
+        metrics={"loss": 0.25},
+        tags={"validation_metrics_unavailable": "not_enough_images"},
+    )
+
+    snapshot = _snapshot_from_run(None, run, "task-1")
+
+    assert snapshot["validation_metrics"] is None
+    assert snapshot["validation_metrics_unavailable"] == "not_enough_images"

--- a/tests/test_model_registry.py
+++ b/tests/test_model_registry.py
@@ -1,0 +1,35 @@
+from types import SimpleNamespace
+
+from app.services import model_registry
+
+
+def test_full_model_info_returns_trained_model_metadata_name(monkeypatch):
+    requested_uris = []
+
+    def get_model_info(uri):
+        requested_uris.append(uri)
+        return SimpleNamespace(
+            metadata={
+                "registry_key": "trained-model",
+                "name": "Trained Model",
+            }
+        )
+
+    monkeypatch.setattr(model_registry.mlflow.models, "get_model_info", get_model_info)
+
+    result = model_registry._full_model_info("trained-model")
+
+    assert requested_uris == ["models:/trained-model/latest"]
+    assert result["name"] == "Trained Model"
+
+
+def test_full_model_info_falls_back_when_metadata_lookup_fails(monkeypatch):
+    def get_model_info(_uri):
+        raise RuntimeError("model version is unavailable")
+
+    monkeypatch.setattr(model_registry.mlflow.models, "get_model_info", get_model_info)
+
+    assert model_registry._full_model_info("missing-model") == {
+        "registry_key": "missing-model",
+        "name": "missing-model",
+    }

--- a/tests/test_model_registry.py
+++ b/tests/test_model_registry.py
@@ -1,3 +1,5 @@
+from contextlib import contextmanager
+import json
 from types import SimpleNamespace
 
 from app.services import model_registry
@@ -21,6 +23,55 @@ def test_full_model_info_returns_trained_model_metadata_name(monkeypatch):
 
     assert requested_uris == ["models:/trained-model/latest"]
     assert result["name"] == "Trained Model"
+
+
+def test_full_model_info_resolves_legacy_training_ids_to_names(monkeypatch):
+    class FakeQuery:
+        def __init__(self, rows):
+            self.rows = rows
+
+        def filter(self, *_conditions):
+            return self
+
+        def first(self):
+            return self.rows[0] if self.rows else None
+
+        def all(self):
+            return self.rows
+
+    dataset = SimpleNamespace(id=1, name="Cells dataset")
+    labels = [
+        SimpleNamespace(id=5, name="cell"),
+        SimpleNamespace(id=6, name="nucleus"),
+    ]
+
+    class FakeDB:
+        def query(self, model):
+            rows = [dataset] if model is model_registry.Datasets else labels
+            return FakeQuery(rows)
+
+    @contextmanager
+    def fake_context_session():
+        yield FakeDB()
+
+    def get_model_info(_uri):
+        return SimpleNamespace(
+            metadata={
+                "registry_key": "legacy-model",
+                "name": "Legacy Model",
+                "label_ids": [5, 6],
+                "tags": {"dataset_id": "1"},
+            }
+        )
+
+    monkeypatch.setattr(model_registry.mlflow.models, "get_model_info", get_model_info)
+    monkeypatch.setattr(model_registry, "get_context_session", fake_context_session)
+
+    result = model_registry._full_model_info("legacy-model")
+
+    assert result["tags"]["trained_on_dataset_id"] == "1"
+    assert result["tags"]["trained_on_dataset_name"] == "Cells dataset"
+    assert json.loads(result["tags"]["trained_label_names"]) == ["cell", "nucleus"]
 
 
 def test_full_model_info_falls_back_when_metadata_lookup_fails(monkeypatch):


### PR DESCRIPTION
- Adds Patch and Override options when applying model predictions.
- Reports clear training states: waiting, in progress, completed, failed, cancelled, and timed out.
- Keeps training runs available after refresh.
- Returns useful messages when training fails, is cancelled, or takes too long to start.
- Makes training quality results and per-label metrics available to the frontend.
- Preserves custom training and model names for the Model Zoo.
- Improves cancellation handling so failed cancellation requests are not shown as successfully cancelled.
- Limitation: Hierarchical instance segmentation is not included in this PR.