### PR TITLE
feat(inference): dispatch model-owned inputs and conditioning

### DIFF
--- a/app/schemas/inference.py
+++ b/app/schemas/inference.py
@@ -81,40 +81,10 @@ class InferenceStepRequest(BaseModel):
         default=None,
         description="Generic inference inputs containing 'conditioning' and 'parameters'.",
     )
-    # --- legacy compatibility fields (synthesized into inputs during plan resolution) ---
     min_confidence: Optional[float] = Field(
         default=0.0, ge=0.0, le=1.0,
-        description="Predictions below this confidence are discarded before merging (legacy).",
+        description="Predictions below this confidence are discarded before merging.",
     )
-    retrieval_strategy: Optional[str] = Field(
-        default=None,
-        description="Exemplar-retrieval strategy; required for cross-image steps (legacy).",
-    )
-    top_k: Optional[int] = Field(
-        default=5, ge=1, le=32,
-        description="How many exemplars a cross-image step retrieves per image (legacy).",
-    )
-
-    @model_validator(mode="before")
-    @classmethod
-    def _ignore_mirrored_legacy_fields_when_inputs_present(cls, data: Any) -> Any:
-        """Treat canonical inputs as authoritative over mirrored retrieval fields.
-
-        ``retrieval_strategy`` and ``top_k`` are mirrored inside ``inputs.conditioning`` and are
-        therefore discarded when canonical inputs are present. ``min_confidence`` is different:
-        it remains a platform-owned post-filter and must survive alongside canonical model inputs.
-        """
-        if isinstance(data, dict) and data.get("inputs") is not None:
-            data = dict(data)
-            for key in ("retrieval_strategy", "top_k"):
-                data.pop(key, None)
-        return data
-
-    @model_validator(mode="after")
-    def _require_strategy_for_cross_image(self) -> "InferenceStepRequest":
-        if self.inputs is None and self.task == "cross-image-suggestion" and not self.retrieval_strategy:
-            raise ValueError("A cross-image step needs a retrieval_strategy.")
-        return self
 
 
 from iquana_toolbox.schemas.input_contract import ConditioningSpec, InputContract

--- a/app/schemas/inference.py
+++ b/app/schemas/inference.py
@@ -97,16 +97,16 @@ class InferenceStepRequest(BaseModel):
 
     @model_validator(mode="before")
     @classmethod
-    def _ignore_legacy_fields_when_inputs_present(cls, data: Any) -> Any:
-        """Treat canonical inputs as authoritative over mirrored legacy fields.
+    def _ignore_mirrored_legacy_fields_when_inputs_present(cls, data: Any) -> Any:
+        """Treat canonical inputs as authoritative over mirrored retrieval fields.
 
-        Older clients may retain stale compatibility values in the same step object. They are
-        irrelevant once ``inputs`` is present, and validating them would allow an obsolete value
-        such as ``min_confidence=50`` to reject an otherwise valid canonical request.
+        ``retrieval_strategy`` and ``top_k`` are mirrored inside ``inputs.conditioning`` and are
+        therefore discarded when canonical inputs are present. ``min_confidence`` is different:
+        it remains a platform-owned post-filter and must survive alongside canonical model inputs.
         """
         if isinstance(data, dict) and data.get("inputs") is not None:
             data = dict(data)
-            for key in ("min_confidence", "retrieval_strategy", "top_k"):
+            for key in ("retrieval_strategy", "top_k"):
                 data.pop(key, None)
         return data
 

--- a/app/schemas/inference.py
+++ b/app/schemas/inference.py
@@ -149,17 +149,7 @@ class ResolvedStep(InferenceStepRequest):
         default_factory=lambda: InputContract(
             task="instance-segmentation",
             conditioning=ConditioningSpec(kind="none", user_selectable_count=False),
-            parameters=[
-                HyperParameter(
-                    key="threshold",
-                    label="Confidence Threshold",
-                    type="float",
-                    default_value=0.5,
-                    min_value=0.0,
-                    max_value=1.0,
-                    step=0.05,
-                )
-            ],
+            parameters=[],
         ),
         description="Snapshot of the effective InputContract resolved for this step.",
     )
@@ -211,7 +201,7 @@ class ResolvedStep(InferenceStepRequest):
 
                 raw_params: dict[str, Any] = {}
                 min_conf = data.get("min_confidence")
-                if min_conf is not None and min_conf > 0.0:
+                if "threshold" in {p.key for p in contract.parameters} and min_conf is not None and min_conf > 0.0:
                     raw_params["threshold"] = min_conf
 
                 normalized = validate_and_normalize_inputs(

--- a/app/schemas/inference.py
+++ b/app/schemas/inference.py
@@ -20,7 +20,7 @@ from __future__ import annotations
 
 from datetime import datetime
 from enum import StrEnum
-from typing import Literal, Optional
+from typing import Any, Literal, Optional
 
 from pydantic import BaseModel, Field, model_validator
 
@@ -77,25 +77,48 @@ class InferenceStepRequest(BaseModel):
         default="instance-segmentation",
         description="Which AI-service surface the model is called on.",
     )
-    min_confidence: float = Field(
-        default=0.0, ge=0.0, le=1.0,
-        description="Predictions below this confidence are discarded before merging.",
+    inputs: Optional[dict[str, Any]] = Field(
+        default=None,
+        description="Generic inference inputs containing 'conditioning' and 'parameters'.",
     )
-    # --- cross-image-suggestion only -------------------------------------------------
+    # --- legacy compatibility fields (synthesized into inputs during plan resolution) ---
+    min_confidence: Optional[float] = Field(
+        default=0.0, ge=0.0, le=1.0,
+        description="Predictions below this confidence are discarded before merging (legacy).",
+    )
     retrieval_strategy: Optional[str] = Field(
         default=None,
-        description="Exemplar-retrieval strategy; required for cross-image steps.",
+        description="Exemplar-retrieval strategy; required for cross-image steps (legacy).",
     )
-    top_k: int = Field(
+    top_k: Optional[int] = Field(
         default=5, ge=1, le=32,
-        description="How many exemplars a cross-image step retrieves per image.",
+        description="How many exemplars a cross-image step retrieves per image (legacy).",
     )
+
+    @model_validator(mode="before")
+    @classmethod
+    def _ignore_legacy_fields_when_inputs_present(cls, data: Any) -> Any:
+        """Treat canonical inputs as authoritative over mirrored legacy fields.
+
+        Older clients may retain stale compatibility values in the same step object. They are
+        irrelevant once ``inputs`` is present, and validating them would allow an obsolete value
+        such as ``min_confidence=50`` to reject an otherwise valid canonical request.
+        """
+        if isinstance(data, dict) and data.get("inputs") is not None:
+            data = dict(data)
+            for key in ("min_confidence", "retrieval_strategy", "top_k"):
+                data.pop(key, None)
+        return data
 
     @model_validator(mode="after")
     def _require_strategy_for_cross_image(self) -> "InferenceStepRequest":
-        if self.task == "cross-image-suggestion" and not self.retrieval_strategy:
+        if self.inputs is None and self.task == "cross-image-suggestion" and not self.retrieval_strategy:
             raise ValueError("A cross-image step needs a retrieval_strategy.")
         return self
+
+
+from iquana_toolbox.schemas.input_contract import ConditioningSpec, InputContract
+from iquana_toolbox.schemas.training import HyperParameter
 
 
 class ResolvedStep(InferenceStepRequest):
@@ -118,6 +141,84 @@ class ResolvedStep(InferenceStepRequest):
                     "down to this step's label; empty means the model is class-agnostic and "
                     "its output is labelled with this step's label.",
     )
+    inputs: dict[str, Any] = Field(
+        default_factory=dict,
+        description="Normalized inference inputs snapshot containing conditioning and parameters.",
+    )
+    input_contract: InputContract = Field(
+        default_factory=lambda: InputContract(
+            task="instance-segmentation",
+            conditioning=ConditioningSpec(kind="none", user_selectable_count=False),
+            parameters=[
+                HyperParameter(
+                    key="threshold",
+                    label="Confidence Threshold",
+                    type="float",
+                    default_value=0.5,
+                    min_value=0.0,
+                    max_value=1.0,
+                    step=0.05,
+                )
+            ],
+        ),
+        description="Snapshot of the effective InputContract resolved for this step.",
+    )
+    provenance: Literal["declared", "legacy_default"] = Field(
+        default="legacy_default",
+        description="Whether the contract was declared by the model or resolved from legacy defaults.",
+    )
+
+    @model_validator(mode="before")
+    @classmethod
+    def _migrate_legacy_persisted_step(cls, data: Any) -> Any:
+        if isinstance(data, dict):
+            task = data.get("task", "instance-segmentation")
+            # If input_contract is missing, resolve task's legacy default contract
+            if "input_contract" not in data or data["input_contract"] is None:
+                from app.services.inference.contract_resolver import LEGACY_TASK_DEFAULTS
+                contract = LEGACY_TASK_DEFAULTS.get(task)
+                if contract is not None:
+                    data["input_contract"] = contract.model_dump()
+                    data["provenance"] = "legacy_default"
+
+            # If inputs is missing, synthesize from step legacy fields
+            if "inputs" not in data or data["inputs"] is None or not data["inputs"]:
+                from app.services.inference.contract_resolver import resolve_input_contract
+                from app.services.inference.input_validator import validate_and_normalize_inputs
+
+                contract_data = data.get("input_contract")
+                contract = (
+                    InputContract.model_validate(contract_data)
+                    if contract_data
+                    else resolve_input_contract(None, task)[0]
+                )
+
+                raw_cond: dict[str, Any] = {}
+                if task == "cross-image-suggestion":
+                    if data.get("retrieval_strategy") is not None:
+                        raw_cond["strategy"] = data.get("retrieval_strategy")
+                    cond = contract.conditioning
+                    top_k = data.get("top_k", 5)
+                    if cond.user_selectable_count:
+                        count = top_k
+                        if cond.max_units is not None:
+                            count = min(count, cond.max_units)
+                        if cond.min_units is not None:
+                            count = max(count, cond.min_units)
+                        raw_cond["count"] = count
+                    elif cond.kind in ("reference_images", "instances", "embeddings"):
+                        raw_cond["count"] = cond.max_units or cond.min_units or 1
+
+                raw_params: dict[str, Any] = {}
+                min_conf = data.get("min_confidence")
+                if min_conf is not None and min_conf > 0.0:
+                    raw_params["threshold"] = min_conf
+
+                normalized = validate_and_normalize_inputs(
+                    contract, {"conditioning": raw_cond, "parameters": raw_params}
+                )
+                data["inputs"] = normalized
+        return data
 
 
 class InferenceOptions(BaseModel):
@@ -295,6 +396,9 @@ class ReplacePreview(BaseModel):
     )
 
 
+from iquana_toolbox.schemas.input_contract import InputContract
+
+
 class ModelOption(BaseModel):
     """One selectable model in the per-label picker."""
 
@@ -314,6 +418,14 @@ class ModelOption(BaseModel):
         default=False,
         description="Whether the model was trained on the dataset being annotated. Models that "
                     "were are sorted first in the picker.",
+    )
+    input_contract: InputContract = Field(
+        ...,
+        description="Effective inference input contract for this model and task.",
+    )
+    provenance: Literal["declared", "legacy_default"] = Field(
+        default="declared",
+        description="Whether the contract was explicitly declared by the model or resolved from legacy task defaults.",
     )
 
 

--- a/app/services/exemplar_retrieval.py
+++ b/app/services/exemplar_retrieval.py
@@ -362,3 +362,16 @@ def retrieve_exemplars(
             detail=f"The {strategy_key!r} retrieval strategy is not available yet.",
         )
     return strategy.retrieve(session, query, model_id)
+
+
+def is_region_based_strategy(strategy_key: str) -> bool:
+    """Return True if strategy requires region-level embeddings (e.g. REGION_MEAN)."""
+    strat = RETRIEVAL_STRATEGIES.get(strategy_key)
+    if strat is not None:
+        return REGION_MEAN in strat.required_kinds
+    return False
+
+
+def get_region_based_strategies() -> set[str]:
+    """Return set of registered strategy keys that require region-level embeddings."""
+    return {k for k, v in RETRIEVAL_STRATEGIES.items() if REGION_MEAN in v.required_kinds}

--- a/app/services/inference/conditioning_dispatcher.py
+++ b/app/services/inference/conditioning_dispatcher.py
@@ -103,48 +103,58 @@ def resolve_reference_images(
                 f"{model_id!r}; embed it first.",
             )
 
-    # Retrieve candidate matches
-    raw_matches = retrieve_exemplars(
-        session,
-        strategy,
-        RetrievalQuery(
-            dataset_id=dataset_id,
-            target_image_id=target_image_id,
-            concept_label_id=concept_label_id,
-            query_vector=query_vector,
-            top_k=32,  # Fetch sufficient candidate pool to find eligible reference images
-        ),
-        model_id=model_id,
-    )
-    if not raw_matches:
-        return [], []
-
-    # Filter out target image and group by image_id
-    matches_by_image: dict[int, list[ExemplarMatch]] = OrderedDict()
-    for match in raw_matches:
-        if match.image_id == target_image_id:
-            continue
-        if match.image_id not in matches_by_image:
-            matches_by_image[match.image_id] = []
-        matches_by_image[match.image_id].append(match)
-
-    # Filter images by complete-annotation requirement if specified
+    # Retrieve candidate matches with progressive search to avoid small hard caps
+    # when filtering candidates by complete annotation. Search until candidate source is exhausted.
     eligible_image_ids: list[int] = []
-    for image_id in matches_by_image.keys():
-        if requires_complete_annotation:
-            if not is_image_fully_annotated(session, image_id):
-                continue
-        eligible_image_ids.append(image_id)
-        if len(eligible_image_ids) >= max_images:
+    matches_by_image: dict[int, list[ExemplarMatch]] = OrderedDict()
+    batch_top_k = 64
+
+    while len(eligible_image_ids) < max_images:
+        raw_matches = retrieve_exemplars(
+            session,
+            strategy,
+            RetrievalQuery(
+                dataset_id=dataset_id,
+                target_image_id=target_image_id,
+                concept_label_id=concept_label_id,
+                query_vector=query_vector,
+                top_k=batch_top_k,
+            ),
+            model_id=model_id,
+        )
+        if not raw_matches:
             break
+
+        matches_by_image.clear()
+        for match in raw_matches:
+            if match.image_id == target_image_id:
+                continue
+            if match.image_id not in matches_by_image:
+                matches_by_image[match.image_id] = []
+            matches_by_image[match.image_id].append(match)
+
+        eligible_image_ids = []
+        for image_id in matches_by_image.keys():
+            if requires_complete_annotation:
+                if not is_image_fully_annotated(session, image_id):
+                    continue
+            eligible_image_ids.append(image_id)
+            if len(eligible_image_ids) >= max_images:
+                break
+
+        if len(eligible_image_ids) >= max_images or len(raw_matches) < batch_top_k:
+            break
+        batch_top_k *= 2
 
     if not eligible_image_ids:
         return [], []
 
-    # Collect selected matches from chosen reference images
+    # Collect selected matches from chosen reference images.
+    # Take the highest-ranked exemplar from each chosen image.
     selected_matches: list[ExemplarMatch] = []
     for img_id in eligible_image_ids:
-        selected_matches.extend(matches_by_image[img_id])
+        img_matches = matches_by_image[img_id]
+        selected_matches.extend(img_matches[:1])
 
     contour_ids = [m.contour_id for m in selected_matches]
     rows = (
@@ -168,7 +178,7 @@ def resolve_reference_images(
             y=contour.y,
             confidence=contour.confidence_score,
         ).to_binary_mask_model(image.height, image.width)
-        exemplars.append(CrossImageExemplar(image_url=image.file_path, mask=mask))
+        exemplars.append(CrossImageExemplar(image_url=str(image.file_path), mask=mask))
 
     return exemplars, selected_matches
 
@@ -180,10 +190,13 @@ def resolve_instance_conditioning(
     concept_label_id: int | None,
     max_instances: int = 5,
     target_image_id: int | None = None,
-) -> list[int]:
-    """Resolve ranked exemplar contour IDs for instance-level conditioning."""
+) -> tuple[list[int], list[Any], list["CrossImageExemplar"]]:
+    """Resolve ranked exemplar contour IDs, materialized BinaryMasks, and source-aware CrossImageExemplars."""
+    from iquana_toolbox.schemas.database.contours import Contour
+    from iquana_toolbox.schemas.networking.http.services import CrossImageExemplar
+
     q = (
-        session.query(Contours.id)
+        session.query(Contours, Images)
         .join(Masks, Masks.id == Contours.mask_id)
         .join(Images, Images.id == Masks.image_id)
         .filter(
@@ -199,7 +212,22 @@ def resolve_instance_conditioning(
     q = q.order_by(Contours.reviewed_by.any().desc(), Contours.created_at.desc())
     if max_instances:
         q = q.limit(max_instances)
-    return [row[0] for row in q.all()]
+
+    rows = q.all()
+    contour_ids: list[int] = []
+    positive_exemplars: list[Any] = []
+    cross_image_exemplars: list[CrossImageExemplar] = []
+    for contour, image in rows:
+        contour_ids.append(contour.id)
+        bm = Contour(
+            x=contour.x,
+            y=contour.y,
+            confidence=contour.confidence_score,
+        ).to_binary_mask_model(image.height, image.width)
+        positive_exemplars.append(bm)
+        cross_image_exemplars.append(CrossImageExemplar(image_url=str(image.file_path), mask=bm))
+
+    return contour_ids, positive_exemplars, cross_image_exemplars
 
 
 CONTOUR_SCOPED_EMBEDDING_KINDS = {REGION_MEAN}
@@ -396,23 +424,97 @@ def dispatch_conditioning(
             "kind": "reference_images",
             "exemplars": exemplars,
             "matches": matches,
+            "contour_ids": [m.contour_id for m in matches],
+            "positive_exemplars": [ex.mask.model_dump(mode="json") if hasattr(ex.mask, "model_dump") else ex.mask for ex in exemplars],
             "concept": concept,
         }
 
     if kind == "instances":
+        strategy = cond_inputs.get("strategy")
+        query_contour_id = cond_inputs.get("query_contour_id")
         count = cond_inputs.get("count") or 5
         if cond_spec.max_units is not None:
             count = min(count, cond_spec.max_units)
         if cond_spec.min_units is not None:
             count = max(count, cond_spec.min_units)
 
-        contour_ids = resolve_instance_conditioning(
-            session,
-            dataset_id=target_image.dataset_id,
-            concept_label_id=step.label_id,
-            max_instances=count,
-            target_image_id=target_image.id,
-        )
+        from iquana_toolbox.schemas.database.labels import Label
+        label_row = session.get(Labels, step.label_id)
+        concept = Label.from_db(label_row) if label_row is not None else None
+
+        if strategy:
+            query_vector = None
+            if query_contour_id is not None and is_region_based_strategy(strategy):
+                contour_row = (
+                    session.query(Contours.id)
+                    .join(Masks, Masks.id == Contours.mask_id)
+                    .join(Images, Images.id == Masks.image_id)
+                    .filter(Contours.id == query_contour_id, Images.dataset_id == target_image.dataset_id)
+                    .first()
+                )
+                if contour_row is None:
+                    raise HTTPException(
+                        status.HTTP_404_NOT_FOUND,
+                        f"Query contour {query_contour_id} not found in dataset {target_image.dataset_id}.",
+                    )
+                query_vector = get_embedding_vector(
+                    session, contour_id=query_contour_id, kind=REGION_MEAN, model_id=EMBEDDING_MODEL_ID
+                )
+                if query_vector is None:
+                    raise HTTPException(
+                        status.HTTP_400_BAD_REQUEST,
+                        f"Query contour {query_contour_id} has no '{REGION_MEAN}' embedding for model "
+                        f"{EMBEDDING_MODEL_ID!r}; embed it first.",
+                    )
+
+            raw_matches = retrieve_exemplars(
+                session,
+                strategy,
+                RetrievalQuery(
+                    dataset_id=target_image.dataset_id,
+                    target_image_id=target_image.id,
+                    concept_label_id=step.label_id,
+                    query_vector=query_vector,
+                    top_k=count,
+                ),
+                model_id=EMBEDDING_MODEL_ID,
+            )
+            matches = [m for m in raw_matches if m.image_id != target_image.id][:count]
+            contour_ids = [m.contour_id for m in matches]
+            rows = (
+                session.query(Contours, Images)
+                .join(Masks, Masks.id == Contours.mask_id)
+                .join(Images, Images.id == Masks.image_id)
+                .filter(Contours.id.in_(contour_ids))
+                .all()
+            )
+            by_id = {contour.id: (contour, image) for contour, image in rows}
+            exemplars: list[CrossImageExemplar] = []
+            positive_exemplars: list[Any] = []
+            for match in matches:
+                pair = by_id.get(match.contour_id)
+                if pair is None:
+                    continue
+                contour, image = pair
+                from iquana_toolbox.schemas.database.contours import Contour
+                from iquana_toolbox.schemas.networking.http.services import CrossImageExemplar
+                bm = Contour(
+                    x=contour.x,
+                    y=contour.y,
+                    confidence=contour.confidence_score,
+                ).to_binary_mask_model(image.height, image.width)
+                positive_exemplars.append(bm)
+                exemplars.append(CrossImageExemplar(image_url=str(image.file_path), mask=bm))
+        else:
+            matches = []
+            contour_ids, positive_exemplars, exemplars = resolve_instance_conditioning(
+                session,
+                dataset_id=target_image.dataset_id,
+                concept_label_id=step.label_id,
+                max_instances=count,
+                target_image_id=target_image.id,
+            )
+
         if cond_spec.min_units > 0 and len(contour_ids) < cond_spec.min_units:
             raise ValueError(
                 f"Resolved {len(contour_ids)} instance exemplar(s) for label {step.label_id} "
@@ -422,6 +524,10 @@ def dispatch_conditioning(
         return {
             "kind": "instances",
             "contour_ids": contour_ids,
+            "positive_exemplars": [bm.model_dump(mode="json") if hasattr(bm, "model_dump") else bm for bm in positive_exemplars],
+            "exemplars": exemplars,
+            "matches": matches,
+            "concept": concept,
         }
 
     if kind == "embeddings":

--- a/app/services/inference/conditioning_dispatcher.py
+++ b/app/services/inference/conditioning_dispatcher.py
@@ -104,10 +104,20 @@ def resolve_reference_images(
             )
 
     # Retrieve candidate matches with progressive search to avoid small hard caps
-    # when filtering candidates by complete annotation. Search until candidate source is exhausted.
+    # when filtering candidates by complete annotation. A global-scene strategy returns only
+    # concept-bearing contours, so its result count is not the number of ranked image candidates.
+    # Use the dataset's image population as the source bound for that strategy and keep widening
+    # even when the current image window has no matching concept contours.
     eligible_image_ids: list[int] = []
     matches_by_image: dict[int, list[ExemplarMatch]] = OrderedDict()
     batch_top_k = 64
+    global_scene_candidate_count: int | None = None
+    if strategy == "global_scene":
+        global_scene_candidate_count = (
+            session.query(Images.id)
+            .filter(Images.dataset_id == dataset_id, Images.id != target_image_id)
+            .count()
+        )
 
     while len(eligible_image_ids) < max_images:
         raw_matches = retrieve_exemplars(
@@ -122,9 +132,6 @@ def resolve_reference_images(
             ),
             model_id=model_id,
         )
-        if not raw_matches:
-            break
-
         matches_by_image.clear()
         for match in raw_matches:
             if match.image_id == target_image_id:
@@ -142,7 +149,22 @@ def resolve_reference_images(
             if len(eligible_image_ids) >= max_images:
                 break
 
-        if len(eligible_image_ids) >= max_images or len(raw_matches) < batch_top_k:
+        if len(eligible_image_ids) >= max_images:
+            break
+
+        if strategy == "global_scene":
+            # ``raw_matches`` may be empty/sparse while search_similar still has more images
+            # to inspect. Once the requested window covers every other dataset image, a sparse
+            # result is a real exhaustion signal for this strategy.
+            if (
+                global_scene_candidate_count == 0
+                or (
+                    len(raw_matches) < batch_top_k
+                    and batch_top_k >= (global_scene_candidate_count or 0)
+                )
+            ):
+                break
+        elif len(raw_matches) < batch_top_k:
             break
         batch_top_k *= 2
 
@@ -195,6 +217,9 @@ def resolve_instance_conditioning(
     from iquana_toolbox.schemas.database.contours import Contour
     from iquana_toolbox.schemas.networking.http.services import CrossImageExemplar
 
+    if max_instances is not None and max_instances <= 0:
+        return [], [], []
+
     q = (
         session.query(Contours, Images)
         .join(Masks, Masks.id == Contours.mask_id)
@@ -210,7 +235,7 @@ def resolve_instance_conditioning(
         q = q.filter(Images.id != target_image_id)
 
     q = q.order_by(Contours.reviewed_by.any().desc(), Contours.created_at.desc())
-    if max_instances:
+    if max_instances is not None:
         q = q.limit(max_instances)
 
     rows = q.all()
@@ -390,12 +415,26 @@ def dispatch_conditioning(
         strategy = cond_inputs.get("strategy") or "global_scene"
         query_contour_id = cond_inputs.get("query_contour_id")
         count = cond_inputs.get("count")
-        if count is None or count < 1:
+        if count is None or (count < 1 and cond_spec.min_units > 0):
             count = cond_spec.max_units or 1
         if cond_spec.max_units is not None:
             count = min(count, cond_spec.max_units)
         if cond_spec.min_units is not None:
             count = max(count, cond_spec.min_units)
+
+        from iquana_toolbox.schemas.database.labels import Label
+        label_row = session.get(Labels, step.label_id)
+        concept = Label.from_db(label_row) if label_row is not None else None
+
+        if count == 0:
+            return {
+                "kind": "reference_images",
+                "exemplars": [],
+                "matches": [],
+                "contour_ids": [],
+                "positive_exemplars": [],
+                "concept": concept,
+            }
 
         exemplars, matches = resolve_reference_images(
             session,
@@ -416,10 +455,6 @@ def dispatch_conditioning(
                 f"{cond_spec.min_units} min_units."
             )
 
-        from iquana_toolbox.schemas.database.labels import Label
-        label_row = session.get(Labels, step.label_id)
-        concept = Label.from_db(label_row) if label_row is not None else None
-
         return {
             "kind": "reference_images",
             "exemplars": exemplars,
@@ -432,7 +467,9 @@ def dispatch_conditioning(
     if kind == "instances":
         strategy = cond_inputs.get("strategy")
         query_contour_id = cond_inputs.get("query_contour_id")
-        count = cond_inputs.get("count") or 5
+        count = cond_inputs.get("count")
+        if count is None or (count == 0 and cond_spec.min_units > 0):
+            count = 5
         if cond_spec.max_units is not None:
             count = min(count, cond_spec.max_units)
         if cond_spec.min_units is not None:
@@ -442,7 +479,12 @@ def dispatch_conditioning(
         label_row = session.get(Labels, step.label_id)
         concept = Label.from_db(label_row) if label_row is not None else None
 
-        if strategy:
+        if count == 0:
+            matches = []
+            contour_ids = []
+            positive_exemplars = []
+            exemplars = []
+        elif strategy:
             query_vector = None
             if query_contour_id is not None and is_region_based_strategy(strategy):
                 contour_row = (
@@ -467,19 +509,53 @@ def dispatch_conditioning(
                         f"{EMBEDDING_MODEL_ID!r}; embed it first.",
                     )
 
-            raw_matches = retrieve_exemplars(
-                session,
-                strategy,
-                RetrievalQuery(
-                    dataset_id=target_image.dataset_id,
-                    target_image_id=target_image.id,
-                    concept_label_id=step.label_id,
-                    query_vector=query_vector,
-                    top_k=count,
-                ),
-                model_id=EMBEDDING_MODEL_ID,
-            )
-            matches = [m for m in raw_matches if m.image_id != target_image.id][:count]
+            # Retrieval strategies rank before this branch removes target-image matches. Widen
+            # the ranked window until enough external matches survive, or the strategy's source
+            # is exhausted. global_scene needs the dataset image bound because it returns only
+            # concept-bearing contours, not every ranked image candidate.
+            retrieval_top_k = count
+            global_scene_candidate_count: int | None = None
+            if strategy == "global_scene":
+                global_scene_candidate_count = (
+                    session.query(Images.id)
+                    .filter(
+                        Images.dataset_id == target_image.dataset_id,
+                        Images.id != target_image.id,
+                    )
+                    .count()
+                )
+
+            while True:
+                raw_matches = retrieve_exemplars(
+                    session,
+                    strategy,
+                    RetrievalQuery(
+                        dataset_id=target_image.dataset_id,
+                        target_image_id=target_image.id,
+                        concept_label_id=step.label_id,
+                        query_vector=query_vector,
+                        top_k=retrieval_top_k,
+                    ),
+                    model_id=EMBEDDING_MODEL_ID,
+                )
+                matches = [m for m in raw_matches if m.image_id != target_image.id]
+                if len(matches) >= count:
+                    matches = matches[:count]
+                    break
+
+                if strategy == "global_scene":
+                    if (
+                        global_scene_candidate_count == 0
+                        or (
+                            len(raw_matches) < retrieval_top_k
+                            and retrieval_top_k >= (global_scene_candidate_count or 0)
+                        )
+                    ):
+                        break
+                elif len(raw_matches) < retrieval_top_k:
+                    break
+                retrieval_top_k *= 2
+
             contour_ids = [m.contour_id for m in matches]
             rows = (
                 session.query(Contours, Images)

--- a/app/services/inference/conditioning_dispatcher.py
+++ b/app/services/inference/conditioning_dispatcher.py
@@ -1,0 +1,455 @@
+"""Conditioning dispatcher and resolvers for inference execution.
+
+Resolves model-required conditioning inputs (reference images, instances, embeddings,
+concept text, or none) based on the model's effective InputContract before worker execution.
+"""
+from __future__ import annotations
+
+from collections import OrderedDict
+from logging import getLogger
+from typing import TYPE_CHECKING, Any, Sequence
+
+from fastapi import HTTPException, status
+from sqlalchemy.orm import Session
+
+from app.database.contours import Contours
+from app.database.embeddings import get_embedding_vector
+from app.database.images import Images
+from app.database.labels import Labels
+from app.database.masks import Masks
+from app.schemas.inference import ResolvedStep
+from app.services.exemplar_retrieval import (
+    IMAGE_CLS,
+    REGION_MEAN,
+    ExemplarMatch,
+    RetrievalQuery,
+    is_region_based_strategy,
+    retrieve_exemplars,
+)
+from config import EMBEDDING_MODEL_ID
+
+if TYPE_CHECKING:
+    from iquana_toolbox.schemas.networking.http.services import CrossImageExemplar
+
+logger = getLogger(__name__)
+
+
+def is_image_fully_annotated(session: Session, image_id: int) -> bool:
+    """Check if an image has a mask marked as fully_annotated with no open rejections."""
+    masks = session.query(Masks).filter(Masks.image_id == image_id).all()
+    if not masks:
+        return False
+    for m in masks:
+        if m.fully_annotated:
+            has_open_rejection = any(r.is_open for r in m.rejections) if m.rejections else False
+            if not has_open_rejection:
+                return True
+    return False
+
+
+def resolve_reference_images(
+    session: Session,
+    *,
+    target_image_id: int,
+    dataset_id: int,
+    strategy: str,
+    concept_label_id: int | None = None,
+    query_contour_id: int | None = None,
+    max_images: int = 1,
+    requires_complete_annotation: bool = True,
+    model_id: str = EMBEDDING_MODEL_ID,
+) -> tuple[list["CrossImageExemplar"], list[ExemplarMatch]]:
+    """Resolve reference image exemplars for cross-image conditioning.
+
+    Steps:
+    1. Retrieve ranked exemplar matches using the specified strategy.
+    2. Exclude the target image (an image cannot be its own exemplar).
+    3. Group matches by source image_id preserving the best rank per image.
+    4. If requires_complete_annotation is True, filter candidate images to only those fully annotated.
+    5. Select up to max_images unique reference images.
+    6. Resolve pixel image paths and binary masks for the selected exemplar contours.
+
+    Returns:
+        A tuple (exemplars, selected_matches).
+    """
+    from iquana_toolbox.schemas.database.contours import Contour
+    from iquana_toolbox.schemas.networking.http.services import CrossImageExemplar
+
+    target = session.get(Images, target_image_id)
+    if target is None:
+        raise HTTPException(status.HTTP_404_NOT_FOUND, f"Target image {target_image_id} not found.")
+
+    query_vector = None
+    if query_contour_id is not None and is_region_based_strategy(strategy):
+        contour_row = (
+            session.query(Contours.id)
+            .join(Masks, Masks.id == Contours.mask_id)
+            .join(Images, Images.id == Masks.image_id)
+            .filter(Contours.id == query_contour_id, Images.dataset_id == dataset_id)
+            .first()
+        )
+        if contour_row is None:
+            raise HTTPException(
+                status.HTTP_404_NOT_FOUND,
+                f"Query contour {query_contour_id} not found in dataset {dataset_id}.",
+            )
+        query_vector = get_embedding_vector(
+            session, contour_id=query_contour_id, kind=REGION_MEAN, model_id=model_id
+        )
+        if query_vector is None:
+            raise HTTPException(
+                status.HTTP_400_BAD_REQUEST,
+                f"Query contour {query_contour_id} has no '{REGION_MEAN}' embedding for model "
+                f"{model_id!r}; embed it first.",
+            )
+
+    # Retrieve candidate matches
+    raw_matches = retrieve_exemplars(
+        session,
+        strategy,
+        RetrievalQuery(
+            dataset_id=dataset_id,
+            target_image_id=target_image_id,
+            concept_label_id=concept_label_id,
+            query_vector=query_vector,
+            top_k=32,  # Fetch sufficient candidate pool to find eligible reference images
+        ),
+        model_id=model_id,
+    )
+    if not raw_matches:
+        return [], []
+
+    # Filter out target image and group by image_id
+    matches_by_image: dict[int, list[ExemplarMatch]] = OrderedDict()
+    for match in raw_matches:
+        if match.image_id == target_image_id:
+            continue
+        if match.image_id not in matches_by_image:
+            matches_by_image[match.image_id] = []
+        matches_by_image[match.image_id].append(match)
+
+    # Filter images by complete-annotation requirement if specified
+    eligible_image_ids: list[int] = []
+    for image_id in matches_by_image.keys():
+        if requires_complete_annotation:
+            if not is_image_fully_annotated(session, image_id):
+                continue
+        eligible_image_ids.append(image_id)
+        if len(eligible_image_ids) >= max_images:
+            break
+
+    if not eligible_image_ids:
+        return [], []
+
+    # Collect selected matches from chosen reference images
+    selected_matches: list[ExemplarMatch] = []
+    for img_id in eligible_image_ids:
+        selected_matches.extend(matches_by_image[img_id])
+
+    contour_ids = [m.contour_id for m in selected_matches]
+    rows = (
+        session.query(Contours, Images)
+        .join(Masks, Masks.id == Contours.mask_id)
+        .join(Images, Images.id == Masks.image_id)
+        .filter(Contours.id.in_(contour_ids))
+        .all()
+    )
+    by_id = {contour.id: (contour, image) for contour, image in rows}
+
+    exemplars: list[CrossImageExemplar] = []
+    for match in selected_matches:
+        pair = by_id.get(match.contour_id)
+        if pair is None:
+            logger.warning("Exemplar contour %s vanished before resolution; skipping.", match.contour_id)
+            continue
+        contour, image = pair
+        mask = Contour(
+            x=contour.x,
+            y=contour.y,
+            confidence=contour.confidence_score,
+        ).to_binary_mask_model(image.height, image.width)
+        exemplars.append(CrossImageExemplar(image_url=image.file_path, mask=mask))
+
+    return exemplars, selected_matches
+
+
+def resolve_instance_conditioning(
+    session: Session,
+    *,
+    dataset_id: int,
+    concept_label_id: int | None,
+    max_instances: int = 5,
+    target_image_id: int | None = None,
+) -> list[int]:
+    """Resolve ranked exemplar contour IDs for instance-level conditioning."""
+    q = (
+        session.query(Contours.id)
+        .join(Masks, Masks.id == Contours.mask_id)
+        .join(Images, Images.id == Masks.image_id)
+        .filter(
+            Images.dataset_id == dataset_id,
+            Contours.temporary.is_(False),
+        )
+    )
+    if concept_label_id is not None:
+        q = q.filter(Contours.label_id == concept_label_id)
+    if target_image_id is not None:
+        q = q.filter(Images.id != target_image_id)
+
+    q = q.order_by(Contours.reviewed_by.any().desc(), Contours.created_at.desc())
+    if max_instances:
+        q = q.limit(max_instances)
+    return [row[0] for row in q.all()]
+
+
+CONTOUR_SCOPED_EMBEDDING_KINDS = {REGION_MEAN}
+
+
+def resolve_embedding_conditioning(
+    session: Session,
+    *,
+    target_image_id: int | None = None,
+    dataset_id: int | None = None,
+    contour_id: int | None = None,
+    kind: str | None = None,
+    kinds: Sequence[str] | None = None,
+    model_id: str = EMBEDDING_MODEL_ID,
+) -> dict[str, list[float]] | list[float] | None:
+    """Resolve precomputed embedding vectors for requested kind(s) against appropriate subject.
+
+    - Whole-image embedding kinds (e.g. `image_cls`) query the store using `image_id`.
+    - Object/contour-level embedding kinds (e.g. `region_mean`) query the store using `contour_id`,
+      scoped to the authorized dataset.
+    """
+    def _find_target_contour_id(img_id: int) -> int | None:
+        c = (
+            session.query(Contours.id)
+            .join(Masks, Masks.id == Contours.mask_id)
+            .filter(Masks.image_id == img_id)
+            .order_by(
+                Contours.reviewed_by.any().desc(),
+                Contours.created_at.desc(),
+                Contours.id.desc(),
+            )
+            .first()
+        )
+        return c[0] if c else None
+
+    def _resolve_contour_id(cid: int | None, img_id: int | None) -> int | None:
+        if cid is not None:
+            if dataset_id is not None:
+                # Verify that the explicit contour_id belongs to dataset_id
+                in_ds = (
+                    session.query(Contours.id)
+                    .join(Masks, Masks.id == Contours.mask_id)
+                    .join(Images, Images.id == Masks.image_id)
+                    .filter(Contours.id == cid, Images.dataset_id == dataset_id)
+                    .first()
+                )
+                if in_ds is None:
+                    return None
+            return cid
+        if img_id is not None:
+            return _find_target_contour_id(img_id)
+        return None
+
+    if kind is not None:
+        if kind in CONTOUR_SCOPED_EMBEDDING_KINDS or (contour_id is not None and target_image_id is None):
+            cid = _resolve_contour_id(contour_id, target_image_id)
+            if cid is None:
+                return None
+            return get_embedding_vector(
+                session, image_id=None, contour_id=cid, kind=kind, model_id=model_id
+            )
+        else:
+            if target_image_id is None:
+                return None
+            return get_embedding_vector(
+                session, image_id=target_image_id, contour_id=None, kind=kind, model_id=model_id
+            )
+
+    requested_kinds = kinds if kinds is not None else (IMAGE_CLS,)
+    vectors: dict[str, list[float]] = {}
+    for k in requested_kinds:
+        if k in CONTOUR_SCOPED_EMBEDDING_KINDS:
+            cid = _resolve_contour_id(contour_id, target_image_id)
+            if cid is not None:
+                vec = get_embedding_vector(
+                    session, image_id=None, contour_id=cid, kind=k, model_id=model_id
+                )
+                if vec is not None:
+                    vectors[k] = vec
+        else:
+            if target_image_id is not None:
+                vec = get_embedding_vector(
+                    session, image_id=target_image_id, contour_id=None, kind=k, model_id=model_id
+                )
+                if vec is not None:
+                    vectors[k] = vec
+    return vectors
+
+
+def resolve_concept_text(
+    *,
+    step_inputs: dict[str, Any],
+    label: Labels | None = None,
+) -> str | None:
+    """Extract concept text from normalized step inputs or target label name."""
+    cond_inputs = step_inputs.get("conditioning", {})
+    if cond_inputs.get("concept_text"):
+        return str(cond_inputs["concept_text"])
+    if label is not None:
+        return label.name
+    return None
+
+
+def dispatch_conditioning(
+    session: Session,
+    step: ResolvedStep,
+    target_image: Images,
+    username: str = "system",
+) -> dict[str, Any]:
+    """Unified closed-enum conditioning dispatcher for worker execution.
+
+    Inspects step.input_contract.conditioning.kind and resolves the required payload.
+
+    Returns a dict with:
+        "kind": conditioning kind string ("none", "concept_text", "reference_images", "instances", "embeddings")
+        and associated resolved payloads.
+
+    Raises:
+        ValueError: If required conditioning cannot satisfy the model contract's min_units,
+            if required embeddings are missing, or if conditioning kind is unsupported.
+    """
+    kind = step.input_contract.conditioning.kind
+    cond_spec = step.input_contract.conditioning
+    cond_inputs = step.inputs.get("conditioning", {})
+
+    if kind == "none":
+        return {"kind": "none"}
+
+    if kind == "concept_text":
+        label_row = session.get(Labels, step.label_id)
+        text = resolve_concept_text(step_inputs=step.inputs, label=label_row)
+        from iquana_toolbox.schemas.database.labels import Label
+        if label_row is not None:
+            concept = Label(
+                id=label_row.id,
+                dataset_id=label_row.dataset_id,
+                name=text or label_row.name,
+                value=label_row.value or 0,
+                parent_id=label_row.parent_id,
+                children=[],
+            )
+        elif text:
+            concept = Label(
+                id=0,
+                dataset_id=0,
+                name=text,
+                value=0,
+                parent_id=None,
+                children=[],
+            )
+        else:
+            concept = None
+        return {
+            "kind": "concept_text",
+            "concept_text": text,
+            "concept": concept,
+        }
+
+    if kind == "reference_images":
+        strategy = cond_inputs.get("strategy") or "global_scene"
+        query_contour_id = cond_inputs.get("query_contour_id")
+        count = cond_inputs.get("count")
+        if count is None or count < 1:
+            count = cond_spec.max_units or 1
+        if cond_spec.max_units is not None:
+            count = min(count, cond_spec.max_units)
+        if cond_spec.min_units is not None:
+            count = max(count, cond_spec.min_units)
+
+        exemplars, matches = resolve_reference_images(
+            session,
+            target_image_id=target_image.id,
+            dataset_id=target_image.dataset_id,
+            strategy=strategy,
+            concept_label_id=step.label_id,
+            query_contour_id=query_contour_id,
+            max_images=count,
+            requires_complete_annotation=cond_spec.requires_complete_annotation,
+        )
+
+        unique_images = {ex.image_url for ex in exemplars}
+        if cond_spec.min_units > 0 and len(unique_images) < cond_spec.min_units:
+            raise ValueError(
+                f"Resolved {len(unique_images)} unique reference image(s) for label {step.label_id} "
+                f"on image {target_image.id}, but model contract for '{step.task}' requires at least "
+                f"{cond_spec.min_units} min_units."
+            )
+
+        from iquana_toolbox.schemas.database.labels import Label
+        label_row = session.get(Labels, step.label_id)
+        concept = Label.from_db(label_row) if label_row is not None else None
+
+        return {
+            "kind": "reference_images",
+            "exemplars": exemplars,
+            "matches": matches,
+            "concept": concept,
+        }
+
+    if kind == "instances":
+        count = cond_inputs.get("count") or 5
+        if cond_spec.max_units is not None:
+            count = min(count, cond_spec.max_units)
+        if cond_spec.min_units is not None:
+            count = max(count, cond_spec.min_units)
+
+        contour_ids = resolve_instance_conditioning(
+            session,
+            dataset_id=target_image.dataset_id,
+            concept_label_id=step.label_id,
+            max_instances=count,
+            target_image_id=target_image.id,
+        )
+        if cond_spec.min_units > 0 and len(contour_ids) < cond_spec.min_units:
+            raise ValueError(
+                f"Resolved {len(contour_ids)} instance exemplar(s) for label {step.label_id} "
+                f"on image {target_image.id}, but model contract for '{step.task}' requires at least "
+                f"{cond_spec.min_units} min_units."
+            )
+        return {
+            "kind": "instances",
+            "contour_ids": contour_ids,
+        }
+
+    if kind == "embeddings":
+        kinds = cond_spec.embedding_kinds or [IMAGE_CLS]
+        query_contour_id = cond_inputs.get("query_contour_id")
+        vectors = resolve_embedding_conditioning(
+            session,
+            target_image_id=target_image.id,
+            dataset_id=target_image.dataset_id,
+            contour_id=query_contour_id,
+            kinds=kinds,
+            model_id=EMBEDDING_MODEL_ID,
+        )
+        missing = [k for k in kinds if k not in vectors]
+        if missing:
+            raise ValueError(
+                f"Image {target_image.id} is missing required embedding(s) {missing} "
+                f"for model {EMBEDDING_MODEL_ID!r}; run the embedding backfill first."
+            )
+        if cond_spec.min_units > 0 and len(vectors) < cond_spec.min_units:
+            raise ValueError(
+                f"Resolved {len(vectors)} embedding vector(s) for image {target_image.id}, "
+                f"but model contract requires at least {cond_spec.min_units} min_units."
+            )
+        return {
+            "kind": "embeddings",
+            "vectors": vectors,
+            "vector": vectors.get(kinds[0]) if len(kinds) == 1 else None,
+        }
+
+    raise ValueError(f"Unsupported conditioning kind '{kind}' for task '{step.task}'")

--- a/app/services/inference/conditioning_dispatcher.py
+++ b/app/services/inference/conditioning_dispatcher.py
@@ -172,11 +172,29 @@ def resolve_reference_images(
         return [], []
 
     # Collect selected matches from chosen reference images.
-    # Take the highest-ranked exemplar from each chosen image.
+    # Include all matching concept exemplars from each chosen reference image so that
+    # all objects of the concept on the reference image are prompted.
     selected_matches: list[ExemplarMatch] = []
     for img_id in eligible_image_ids:
-        img_matches = matches_by_image[img_id]
-        selected_matches.extend(img_matches[:1])
+        img_matches = matches_by_image.get(img_id, [])
+        known_contour_ids = {m.contour_id for m in img_matches}
+        selected_matches.extend(img_matches)
+        if concept_label_id is not None:
+            extra_contours = (
+                session.query(Contours.id)
+                .join(Masks, Masks.id == Contours.mask_id)
+                .filter(
+                    Masks.image_id == img_id,
+                    Contours.temporary.is_(False),
+                    Contours.label_id == concept_label_id,
+                    Contours.id.notin_(known_contour_ids) if known_contour_ids else True,
+                )
+                .order_by(Contours.reviewed_by.any().desc(), Contours.created_at.desc(), Contours.id.desc())
+                .all()
+            )
+            fallback_score = img_matches[0].score if img_matches else 1.0
+            for row in extra_contours:
+                selected_matches.append(ExemplarMatch(contour_id=row[0], image_id=img_id, score=fallback_score))
 
     contour_ids = [m.contour_id for m in selected_matches]
     rows = (
@@ -340,6 +358,145 @@ def resolve_embedding_conditioning(
                 if vec is not None:
                     vectors[k] = vec
     return vectors
+
+
+def resolve_in_context_embedding_conditioning(
+    session: Session,
+    *,
+    dataset_id: int,
+    concept_label_id: int | None,
+    count: int = 1,
+    strategy: str | None = None,
+    target_image_id: int | None = None,
+    query_contour_id: int | None = None,
+    kinds: Sequence[str] | None = None,
+    model_id: str = EMBEDDING_MODEL_ID,
+) -> tuple[dict[str, list[list[float]]], list[int], list[ExemplarMatch]]:
+    """Resolve in-context concept exemplar embedding vectors from other dataset images.
+
+    Retrieves up to ``count`` concept exemplars from images other than ``target_image_id``,
+    and extracts their precomputed embeddings for the requested ``kinds``.
+    """
+    if count <= 0:
+        return {}, [], []
+
+    requested_kinds = kinds if kinds is not None else (REGION_MEAN,)
+    query_vector = None
+    if query_contour_id is not None and strategy and is_region_based_strategy(strategy):
+        query_vector = get_embedding_vector(
+            session, contour_id=query_contour_id, kind=REGION_MEAN, model_id=model_id
+        )
+
+    resolved_cids: list[int] = []
+    resolved_matches: list[ExemplarMatch] = []
+    vectors_by_kind: dict[str, list[list[float]]] = {k: [] for k in requested_kinds}
+
+    if strategy:
+        retrieval_top_k = max(count * 2, 64)
+        global_scene_candidate_count: int | None = None
+        if strategy == "global_scene":
+            global_scene_candidate_count = (
+                session.query(Images.id)
+                .filter(Images.dataset_id == dataset_id, Images.id != target_image_id)
+                .count()
+            )
+
+        while len(resolved_cids) < count:
+            raw_matches = retrieve_exemplars(
+                session,
+                strategy,
+                RetrievalQuery(
+                    dataset_id=dataset_id,
+                    target_image_id=target_image_id,
+                    concept_label_id=concept_label_id,
+                    query_vector=query_vector,
+                    top_k=retrieval_top_k,
+                ),
+                model_id=model_id,
+            )
+            filtered_matches = [m for m in raw_matches if target_image_id is None or m.image_id != target_image_id]
+            for match in filtered_matches:
+                if match.contour_id in resolved_cids:
+                    continue
+                match_vectors: dict[str, list[float]] = {}
+                has_all_kinds = True
+                for k in requested_kinds:
+                    if k in CONTOUR_SCOPED_EMBEDDING_KINDS:
+                        v = get_embedding_vector(
+                            session, image_id=None, contour_id=match.contour_id, kind=k, model_id=model_id
+                        )
+                    else:
+                        v = get_embedding_vector(
+                            session, image_id=match.image_id, contour_id=None, kind=k, model_id=model_id
+                        )
+                    if v is None:
+                        has_all_kinds = False
+                        break
+                    match_vectors[k] = v
+
+                if has_all_kinds:
+                    resolved_cids.append(match.contour_id)
+                    resolved_matches.append(match)
+                    for k, vec in match_vectors.items():
+                        vectors_by_kind[k].append(vec)
+                    if len(resolved_cids) >= count:
+                        break
+
+            if strategy == "global_scene":
+                if (
+                    global_scene_candidate_count == 0
+                    or (
+                        len(raw_matches) < retrieval_top_k
+                        and retrieval_top_k >= (global_scene_candidate_count or 0)
+                    )
+                ):
+                    break
+            elif len(raw_matches) < retrieval_top_k or len(resolved_cids) >= count:
+                break
+            retrieval_top_k *= 2
+    else:
+        q = (
+            session.query(Contours.id, Images.id)
+            .join(Masks, Masks.id == Contours.mask_id)
+            .join(Images, Images.id == Masks.image_id)
+            .filter(
+                Images.dataset_id == dataset_id,
+                Contours.temporary.is_(False),
+            )
+        )
+        if concept_label_id is not None:
+            q = q.filter(Contours.label_id == concept_label_id)
+        if target_image_id is not None:
+            q = q.filter(Images.id != target_image_id)
+        q = q.order_by(Contours.reviewed_by.any().desc(), Contours.created_at.desc(), Contours.id.desc())
+        candidates = q.all()
+
+        for cid, img_id in candidates:
+            match_vectors = {}
+            has_all_kinds = True
+            for k in requested_kinds:
+                if k in CONTOUR_SCOPED_EMBEDDING_KINDS:
+                    v = get_embedding_vector(
+                        session, image_id=None, contour_id=cid, kind=k, model_id=model_id
+                    )
+                else:
+                    v = get_embedding_vector(
+                        session, image_id=img_id, contour_id=None, kind=k, model_id=model_id
+                    )
+                if v is None:
+                    has_all_kinds = False
+                    break
+                match_vectors[k] = v
+
+            if has_all_kinds:
+                resolved_cids.append(cid)
+                resolved_matches.append(ExemplarMatch(contour_id=cid, image_id=img_id, score=1.0))
+                for k, vec in match_vectors.items():
+                    vectors_by_kind[k].append(vec)
+                if len(resolved_cids) >= count:
+                    break
+
+    return vectors_by_kind, resolved_cids, resolved_matches
 
 
 def resolve_concept_text(
@@ -609,29 +766,95 @@ def dispatch_conditioning(
     if kind == "embeddings":
         kinds = cond_spec.embedding_kinds or [IMAGE_CLS]
         query_contour_id = cond_inputs.get("query_contour_id")
-        vectors = resolve_embedding_conditioning(
-            session,
-            target_image_id=target_image.id,
-            dataset_id=target_image.dataset_id,
-            contour_id=query_contour_id,
-            kinds=kinds,
-            model_id=EMBEDDING_MODEL_ID,
+        strategy = cond_inputs.get("strategy")
+        count = cond_inputs.get("count")
+
+        from iquana_toolbox.schemas.database.labels import Label
+        label_row = session.get(Labels, step.label_id) if step.label_id else None
+        concept = Label.from_db(label_row) if label_row is not None else None
+
+        is_in_context = (
+            step.label_id is not None
+            and (
+                (count is not None and count > 0)
+                or cond_spec.min_units > 0
+                or cond_spec.user_selectable_count
+            )
         )
-        missing = [k for k in kinds if k not in vectors]
-        if missing:
-            raise ValueError(
-                f"Image {target_image.id} is missing required embedding(s) {missing} "
-                f"for model {EMBEDDING_MODEL_ID!r}; run the embedding backfill first."
+
+        if is_in_context:
+            target_count = count if count is not None and count > 0 else (cond_spec.max_units or cond_spec.min_units or 1)
+            if cond_spec.max_units is not None:
+                target_count = min(target_count, cond_spec.max_units)
+            if cond_spec.min_units is not None:
+                target_count = max(target_count, cond_spec.min_units)
+
+            vectors_by_kind, contour_ids, matches = resolve_in_context_embedding_conditioning(
+                session,
+                dataset_id=target_image.dataset_id,
+                concept_label_id=step.label_id,
+                count=target_count,
+                strategy=strategy,
+                target_image_id=target_image.id,
+                query_contour_id=query_contour_id,
+                kinds=kinds,
+                model_id=EMBEDDING_MODEL_ID,
             )
-        if cond_spec.min_units > 0 and len(vectors) < cond_spec.min_units:
-            raise ValueError(
-                f"Resolved {len(vectors)} embedding vector(s) for image {target_image.id}, "
-                f"but model contract requires at least {cond_spec.min_units} min_units."
+
+            resolved_vector_count = max((len(v_list) for v_list in vectors_by_kind.values()), default=0)
+            if cond_spec.min_units > 0 and resolved_vector_count < cond_spec.min_units:
+                raise ValueError(
+                    f"Resolved {resolved_vector_count} exemplar vector(s) for label {step.label_id} "
+                    f"on image {target_image.id}, but model contract for '{step.task}' requires at least "
+                    f"{cond_spec.min_units} min_units."
+                )
+
+            vectors_payload: dict[str, Any] = {}
+            for k in kinds:
+                vecs = vectors_by_kind.get(k, [])
+                if len(vecs) == 1 and not cond_spec.user_selectable_count and cond_spec.max_units == 1:
+                    vectors_payload[k] = vecs[0]
+                else:
+                    vectors_payload[k] = vecs
+
+            primary_kind = kinds[0]
+            first_vector = vectors_by_kind.get(primary_kind, [None])[0] if vectors_by_kind.get(primary_kind) else None
+
+            return {
+                "kind": "embeddings",
+                "vectors": vectors_payload,
+                "vectors_by_kind": vectors_by_kind,
+                "vector": first_vector,
+                "exemplar_vectors": vectors_by_kind.get(primary_kind, []),
+                "contour_ids": contour_ids,
+                "matches": matches,
+                "concept": concept,
+            }
+        else:
+            vectors = resolve_embedding_conditioning(
+                session,
+                target_image_id=target_image.id,
+                dataset_id=target_image.dataset_id,
+                contour_id=query_contour_id,
+                kinds=kinds,
+                model_id=EMBEDDING_MODEL_ID,
             )
-        return {
-            "kind": "embeddings",
-            "vectors": vectors,
-            "vector": vectors.get(kinds[0]) if len(kinds) == 1 else None,
-        }
+            missing = [k for k in kinds if k not in vectors]
+            if missing:
+                raise ValueError(
+                    f"Image {target_image.id} is missing required embedding(s) {missing} "
+                    f"for model {EMBEDDING_MODEL_ID!r}; run the embedding backfill first."
+                )
+            if cond_spec.min_units > 0 and len(vectors) < cond_spec.min_units:
+                raise ValueError(
+                    f"Resolved {len(vectors)} embedding vector(s) for image {target_image.id}, "
+                    f"but model contract requires at least {cond_spec.min_units} min_units."
+                )
+            return {
+                "kind": "embeddings",
+                "vectors": vectors,
+                "vector": vectors.get(kinds[0]) if len(kinds) == 1 else None,
+                "concept": concept,
+            }
 
     raise ValueError(f"Unsupported conditioning kind '{kind}' for task '{step.task}'")

--- a/app/services/inference/contract_resolver.py
+++ b/app/services/inference/contract_resolver.py
@@ -1,0 +1,230 @@
+"""Effective inference input contract resolver.
+
+Resolves model-declared contracts and per-task legacy defaults with provenance tracking.
+"""
+from __future__ import annotations
+
+import json
+from typing import Any, Literal
+
+from iquana_toolbox.schemas.input_contract import ConditioningSpec, InputContract
+from iquana_toolbox.schemas.model_info import ModelInfo
+from iquana_toolbox.schemas.training import HyperParameter
+
+Provenance = Literal["declared", "legacy_default"]
+
+#: Explicit per-task legacy default contracts preserving existing platform behavior.
+LEGACY_TASK_DEFAULTS: dict[str, InputContract] = {
+    "instance-segmentation": InputContract(
+        task="instance-segmentation",
+        conditioning=ConditioningSpec(kind="none", user_selectable_count=False),
+        parameters=[
+            HyperParameter(
+                key="threshold",
+                label="Confidence Threshold",
+                type="float",
+                default_value=0.5,
+                min_value=0.0,
+                max_value=1.0,
+                step=0.05,
+            )
+        ],
+        notes="Legacy default contract for autonomous instance segmentation.",
+    ),
+    "cross-image-suggestion": InputContract(
+        task="cross-image-suggestion",
+        conditioning=ConditioningSpec(
+            kind="reference_images",
+            unit="image",
+            min_units=1,
+            max_units=1,
+            requires_complete_annotation=True,
+            user_selectable_count=False,
+        ),
+        parameters=[
+            HyperParameter(
+                key="threshold",
+                label="Confidence Threshold",
+                type="float",
+                default_value=0.3,
+                min_value=0.0,
+                max_value=1.0,
+                step=0.05,
+            ),
+            HyperParameter(
+                key="mask_threshold",
+                label="Mask Threshold",
+                type="float",
+                default_value=0.5,
+                min_value=0.0,
+                max_value=1.0,
+                step=0.05,
+            ),
+            HyperParameter(
+                key="min_target_frac",
+                label="Min Target Fraction",
+                type="float",
+                default_value=0.5,
+                min_value=0.0,
+                max_value=1.0,
+                step=0.05,
+            ),
+        ],
+        notes="Legacy default contract for cross-image exemplar transfer.",
+    ),
+    "instance-suggestion": InputContract(
+        task="instance-suggestion",
+        conditioning=ConditioningSpec(
+            kind="instances",
+            unit="instance",
+            min_units=1,
+            max_units=None,
+            user_selectable_count=True,
+        ),
+        parameters=[
+            HyperParameter(
+                key="threshold",
+                label="Confidence Threshold",
+                type="float",
+                default_value=0.3,
+                min_value=0.0,
+                max_value=1.0,
+                step=0.05,
+            ),
+            HyperParameter(
+                key="mask_threshold",
+                label="Mask Threshold",
+                type="float",
+                default_value=0.5,
+                min_value=0.0,
+                max_value=1.0,
+                step=0.05,
+            ),
+        ],
+        notes="Legacy default contract for interactive instance suggestion.",
+    ),
+    "prompted-segmentation": InputContract(
+        task="prompted-segmentation",
+        conditioning=ConditioningSpec(kind="none", user_selectable_count=False),
+        parameters=[],
+        notes="Legacy default contract for point/box prompted segmentation.",
+    ),
+}
+
+
+def _extract_raw_contracts(model_info: dict[str, Any] | ModelInfo | None) -> list[Any] | None:
+    """Extract raw contract items from a ModelInfo instance or dictionary."""
+    if model_info is None:
+        return None
+
+    if isinstance(model_info, ModelInfo):
+        if not isinstance(model_info.input_contracts, list):
+            raise ValueError(
+                f"Malformed declared input_contracts: expected list, got {type(model_info.input_contracts).__name__}"
+            )
+        return model_info.input_contracts
+
+    if not isinstance(model_info, dict):
+        raise ValueError(f"model_info must be a ModelInfo, dict, or None, got {type(model_info).__name__}")
+
+    if "input_contracts" in model_info:
+        raw = model_info["input_contracts"]
+        if raw is None:
+            raise ValueError("Malformed declared input_contracts: expected list, got None")
+        if isinstance(raw, str):
+            try:
+                raw = json.loads(raw)
+            except Exception as exc:
+                raise ValueError(f"Malformed declared input_contracts JSON: {exc}") from exc
+        if not isinstance(raw, list):
+            raise ValueError(
+                f"Malformed declared input_contracts: expected list, got {type(raw).__name__ if raw is not None else 'None'}"
+            )
+        return raw
+
+    tags = model_info.get("tags")
+    if isinstance(tags, dict) and "input_contracts" in tags:
+        tag_val = tags["input_contracts"]
+        if tag_val is None:
+            raise ValueError("Malformed declared input_contracts in tags: expected list, got None")
+        if isinstance(tag_val, str):
+            try:
+                tag_val = json.loads(tag_val)
+            except Exception as exc:
+                raise ValueError(f"Malformed input_contracts tag JSON: {exc}") from exc
+        if not isinstance(tag_val, list):
+            raise ValueError(
+                f"Malformed declared input_contracts in tags: expected list, got {type(tag_val).__name__ if tag_val is not None else 'None'}"
+            )
+        return tag_val
+    elif isinstance(tags, list):
+        for tag in tags:
+            if isinstance(tag, dict) and tag.get("key") == "input_contracts":
+                val = tag.get("value")
+                if val is None:
+                    raise ValueError("Malformed declared input_contracts in tag value: expected list, got None")
+                if isinstance(val, str):
+                    try:
+                        val = json.loads(val)
+                    except Exception as exc:
+                        raise ValueError(f"Malformed input_contracts tag JSON: {exc}") from exc
+                if not isinstance(val, list):
+                    raise ValueError(
+                        f"Malformed declared input_contracts in tag value: expected list, got {type(val).__name__ if val is not None else 'None'}"
+                    )
+                return val
+
+    return None
+
+
+def resolve_input_contract(
+    model_info: dict[str, Any] | ModelInfo | None,
+    task: str,
+) -> tuple[InputContract, Provenance]:
+    """Resolve the effective InputContract and provenance for a model and task.
+
+    Args:
+        model_info: ModelInfo schema object, dictionary, or None.
+        task: Target task surface name (e.g. "instance-segmentation", "cross-image-suggestion").
+
+    Returns:
+        A tuple of `(effective_contract, provenance)` where provenance is `"declared"`
+        if the model provided a valid contract for `task`, or `"legacy_default"` if
+        resolved from fallback task defaults.
+
+    Raises:
+        ValueError: If declared contracts contain duplicate tasks, malformed data, or
+            if `task` is unknown and has no declared contract.
+    """
+    raw_list = _extract_raw_contracts(model_info)
+
+    if raw_list is not None:
+        if not isinstance(raw_list, list):
+            raise ValueError(f"Malformed declared input contracts: expected list, got {type(raw_list).__name__}")
+        parsed_contracts: list[InputContract] = []
+        seen_tasks: set[str] = set()
+
+        for item in raw_list:
+            if isinstance(item, InputContract):
+                contract = item
+            elif isinstance(item, dict):
+                try:
+                    contract = InputContract.model_validate(item)
+                except Exception as exc:
+                    raise ValueError(f"Malformed declared input contract: {exc}") from exc
+            else:
+                raise ValueError(f"Invalid input contract item type: {type(item).__name__}")
+
+            if contract.task in seen_tasks:
+                raise ValueError(f"Duplicate declared input contract for task '{contract.task}'")
+            seen_tasks.add(contract.task)
+            parsed_contracts.append(contract)
+
+        for contract in parsed_contracts:
+            if contract.task == task:
+                return contract, "declared"
+
+    if task in LEGACY_TASK_DEFAULTS:
+        return LEGACY_TASK_DEFAULTS[task], "legacy_default"
+
+    raise ValueError(f"Unknown task '{task}' with no declared contract or legacy default.")

--- a/app/services/inference/contract_resolver.py
+++ b/app/services/inference/contract_resolver.py
@@ -18,58 +18,19 @@ LEGACY_TASK_DEFAULTS: dict[str, InputContract] = {
     "instance-segmentation": InputContract(
         task="instance-segmentation",
         conditioning=ConditioningSpec(kind="none", user_selectable_count=False),
-        parameters=[
-            HyperParameter(
-                key="threshold",
-                label="Confidence Threshold",
-                type="float",
-                default_value=0.5,
-                min_value=0.0,
-                max_value=1.0,
-                step=0.05,
-            )
-        ],
+        parameters=[],
         notes="Legacy default contract for autonomous instance segmentation.",
     ),
     "cross-image-suggestion": InputContract(
         task="cross-image-suggestion",
         conditioning=ConditioningSpec(
-            kind="reference_images",
-            unit="image",
+            kind="instances",
+            unit="instance",
             min_units=1,
-            max_units=1,
-            requires_complete_annotation=True,
-            user_selectable_count=False,
+            max_units=32,
+            user_selectable_count=True,
         ),
-        parameters=[
-            HyperParameter(
-                key="threshold",
-                label="Confidence Threshold",
-                type="float",
-                default_value=0.3,
-                min_value=0.0,
-                max_value=1.0,
-                step=0.05,
-            ),
-            HyperParameter(
-                key="mask_threshold",
-                label="Mask Threshold",
-                type="float",
-                default_value=0.5,
-                min_value=0.0,
-                max_value=1.0,
-                step=0.05,
-            ),
-            HyperParameter(
-                key="min_target_frac",
-                label="Min Target Fraction",
-                type="float",
-                default_value=0.5,
-                min_value=0.0,
-                max_value=1.0,
-                step=0.05,
-            ),
-        ],
+        parameters=[],
         notes="Legacy default contract for cross-image exemplar transfer.",
     ),
     "instance-suggestion": InputContract(
@@ -78,29 +39,10 @@ LEGACY_TASK_DEFAULTS: dict[str, InputContract] = {
             kind="instances",
             unit="instance",
             min_units=1,
-            max_units=None,
+            max_units=32,
             user_selectable_count=True,
         ),
-        parameters=[
-            HyperParameter(
-                key="threshold",
-                label="Confidence Threshold",
-                type="float",
-                default_value=0.3,
-                min_value=0.0,
-                max_value=1.0,
-                step=0.05,
-            ),
-            HyperParameter(
-                key="mask_threshold",
-                label="Mask Threshold",
-                type="float",
-                default_value=0.5,
-                min_value=0.0,
-                max_value=1.0,
-                step=0.05,
-            ),
-        ],
+        parameters=[],
         notes="Legacy default contract for interactive instance suggestion.",
     ),
     "prompted-segmentation": InputContract(
@@ -127,21 +69,8 @@ def _extract_raw_contracts(model_info: dict[str, Any] | ModelInfo | None) -> lis
     if not isinstance(model_info, dict):
         raise ValueError(f"model_info must be a ModelInfo, dict, or None, got {type(model_info).__name__}")
 
-    if "input_contracts" in model_info:
-        raw = model_info["input_contracts"]
-        if raw is None:
-            raise ValueError("Malformed declared input_contracts: expected list, got None")
-        if isinstance(raw, str):
-            try:
-                raw = json.loads(raw)
-            except Exception as exc:
-                raise ValueError(f"Malformed declared input_contracts JSON: {exc}") from exc
-        if not isinstance(raw, list):
-            raise ValueError(
-                f"Malformed declared input_contracts: expected list, got {type(raw).__name__ if raw is not None else 'None'}"
-            )
-        return raw
-
+    # Registered model tags take precedence over artifact-level metadata so synchronized
+    # updates are visible without re-logging artifacts.
     tags = model_info.get("tags")
     if isinstance(tags, dict) and "input_contracts" in tags:
         tag_val = tags["input_contracts"]
@@ -173,6 +102,21 @@ def _extract_raw_contracts(model_info: dict[str, Any] | ModelInfo | None) -> lis
                         f"Malformed declared input_contracts in tag value: expected list, got {type(val).__name__ if val is not None else 'None'}"
                     )
                 return val
+
+    if "input_contracts" in model_info:
+        raw = model_info["input_contracts"]
+        if raw is None:
+            raise ValueError("Malformed declared input_contracts: expected list, got None")
+        if isinstance(raw, str):
+            try:
+                raw = json.loads(raw)
+            except Exception as exc:
+                raise ValueError(f"Malformed declared input_contracts JSON: {exc}") from exc
+        if not isinstance(raw, list):
+            raise ValueError(
+                f"Malformed declared input_contracts: expected list, got {type(raw).__name__ if raw is not None else 'None'}"
+            )
+        return raw
 
     return None
 

--- a/app/services/inference/execution.py
+++ b/app/services/inference/execution.py
@@ -80,8 +80,12 @@ def _predict_instance_segmentation(
     db: Session, step: ResolvedStep, image: Images, username: str
 ) -> list[Contour]:
     from app.services.ai_services.instance_segmentation import InstanceSegmentationService
+    from app.services.inference.conditioning_dispatcher import dispatch_conditioning
 
+    cond_result = dispatch_conditioning(db, step, image, username)
     label_row = db.get(Labels, step.label_id)
+    parameters = step.inputs.get("parameters", {})
+
     request = InstanceSegmentationRequest(
         image_url=str(image.file_path),
         user_id=username,
@@ -89,6 +93,9 @@ def _predict_instance_segmentation(
         # Multiclass models honour this and return only the asked-for class; models that
         # ignore it are filtered gateway-side anyway (see filter_for_step).
         label=Label.from_db(label_row) if label_row is not None else None,
+        parameters=parameters,
+        contour_ids=cond_result.get("contour_ids", []),
+        embeddings=cond_result.get("vectors", {}),
     )
     response = asyncio.run(InstanceSegmentationService().inference(request))
     return _as_contours(response)
@@ -98,23 +105,43 @@ def _predict_cross_image(
     db: Session, step: ResolvedStep, image: Images, username: str
 ) -> list[Contour]:
     from app.services.ai_services.cross_image import CrossImageService
-    from app.services.cross_image_orchestration import build_cross_image_request
+    from app.services.inference.conditioning_dispatcher import dispatch_conditioning
+    from iquana_toolbox.schemas.networking.http.services import CrossImageSuggestionRequest
 
-    request, matches = build_cross_image_request(
-        db,
-        target_image_id=image.id,
-        strategy=step.retrieval_strategy,
-        concept_label_id=step.label_id,
-        top_k=step.top_k,
-        cross_image_model_key=step.model_registry_key,
+    cond_result = dispatch_conditioning(db, step, image, username)
+    cond_kind = step.input_contract.conditioning.kind
+
+    if cond_kind == "reference_images":
+        exemplars = cond_result.get("exemplars", [])
+        if not exemplars:
+            logger.info(
+                "No exemplars for label %s on image %s; nothing to predict.",
+                step.label_id,
+                image.id,
+            )
+            return []
+    else:
+        exemplars = cond_result.get("exemplars", [])
+
+    parameters = step.inputs.get("parameters", {})
+
+    request = CrossImageSuggestionRequest(
+        image_url=str(image.file_path),
         user_id=username,
+        model_registry_key=step.model_registry_key,
+        exemplars=exemplars,
+        concept=cond_result.get("concept"),
+        parameters=parameters,
+        contour_ids=cond_result.get("contour_ids", []),
+        embeddings=cond_result.get("vectors", {}),
     )
-    if request is None:
-        logger.info("No exemplars for label %s on image %s; nothing to predict.",
-                    step.label_id, image.id)
-        return []
-    logger.debug("Image %s: %d exemplars retrieved for label %s.",
-                 image.id, len(matches), step.label_id)
+    logger.debug(
+        "Image %s: %d exemplars retrieved for label %s (conditioning kind: %s).",
+        image.id,
+        len(exemplars),
+        step.label_id,
+        cond_kind,
+    )
     return _as_contours(asyncio.run(CrossImageService().inference(request)))
 
 
@@ -233,7 +260,8 @@ def run_unit(
     except Exception as exc:  # network, model load, bad response -- all report the same way
         raise InferenceUnitError(_prediction_error(exc, step)) from exc
 
-    candidates = filter_for_step(raw, step, min_confidence=step.min_confidence)
+    threshold = step.inputs.get("parameters", {}).get("threshold", step.min_confidence or 0.0)
+    candidates = filter_for_step(raw, step, min_confidence=threshold)
     if not candidates:
         return UnitResult()
 

--- a/app/services/inference/execution.py
+++ b/app/services/inference/execution.py
@@ -95,6 +95,7 @@ def _predict_instance_segmentation(
         label=Label.from_db(label_row) if label_row is not None else None,
         parameters=parameters,
         contour_ids=cond_result.get("contour_ids", []),
+        positive_exemplars=cond_result.get("positive_exemplars", []),
         embeddings=cond_result.get("vectors", {}),
     )
     response = asyncio.run(InstanceSegmentationService().inference(request))
@@ -111,7 +112,7 @@ def _predict_cross_image(
     cond_result = dispatch_conditioning(db, step, image, username)
     cond_kind = step.input_contract.conditioning.kind
 
-    if cond_kind == "reference_images":
+    if cond_kind in ("reference_images", "instances"):
         exemplars = cond_result.get("exemplars", [])
         if not exemplars:
             logger.info(
@@ -133,6 +134,7 @@ def _predict_cross_image(
         concept=cond_result.get("concept"),
         parameters=parameters,
         contour_ids=cond_result.get("contour_ids", []),
+        positive_exemplars=cond_result.get("positive_exemplars", []),
         embeddings=cond_result.get("vectors", {}),
     )
     logger.debug(

--- a/app/services/inference/execution.py
+++ b/app/services/inference/execution.py
@@ -127,6 +127,9 @@ def _predict_cross_image(
 
     parameters = step.inputs.get("parameters", {})
 
+    vectors_by_kind = cond_result.get("vectors_by_kind", {})
+    embeddings = cond_result.get("vectors", {}) if not vectors_by_kind else {}
+
     request = CrossImageSuggestionRequest(
         image_url=str(image.file_path),
         user_id=username,
@@ -136,7 +139,8 @@ def _predict_cross_image(
         parameters=parameters,
         contour_ids=cond_result.get("contour_ids", []),
         positive_exemplars=cond_result.get("positive_exemplars", []),
-        embeddings=cond_result.get("vectors", {}),
+        embeddings=embeddings,
+        exemplar_embeddings=vectors_by_kind,
     )
     logger.debug(
         "Image %s: %d exemplars retrieved for label %s (conditioning kind: %s).",
@@ -263,8 +267,7 @@ def run_unit(
     except Exception as exc:  # network, model load, bad response -- all report the same way
         raise InferenceUnitError(_prediction_error(exc, step)) from exc
 
-    threshold = step.inputs.get("parameters", {}).get("threshold", step.min_confidence or 0.0)
-    candidates = filter_for_step(raw, step, min_confidence=threshold)
+    candidates = filter_for_step(raw, step, min_confidence=step.min_confidence or 0.0)
     if not candidates:
         return UnitResult()
 

--- a/app/services/inference/execution.py
+++ b/app/services/inference/execution.py
@@ -96,6 +96,7 @@ def _predict_instance_segmentation(
         parameters=parameters,
         contour_ids=cond_result.get("contour_ids", []),
         positive_exemplars=cond_result.get("positive_exemplars", []),
+        exemplars=cond_result.get("exemplars", []),
         embeddings=cond_result.get("vectors", {}),
     )
     response = asyncio.run(InstanceSegmentationService().inference(request))
@@ -114,7 +115,7 @@ def _predict_cross_image(
 
     if cond_kind in ("reference_images", "instances"):
         exemplars = cond_result.get("exemplars", [])
-        if not exemplars:
+        if not exemplars and step.input_contract.conditioning.min_units > 0:
             logger.info(
                 "No exemplars for label %s on image %s; nothing to predict.",
                 step.label_id,

--- a/app/services/inference/input_validator.py
+++ b/app/services/inference/input_validator.py
@@ -254,7 +254,21 @@ def validate_and_normalize_inputs(
 
         elif cond_kind == "embeddings":
             if strategy is not None:
-                raise ValueError("Conditioning kind 'embeddings' does not accept a retrieval strategy.")
+                effective_strat = strategy
+                from app.services.exemplar_retrieval import (
+                    RETRIEVAL_STRATEGIES,
+                    is_region_based_strategy,
+                )
+                if effective_strat not in RETRIEVAL_STRATEGIES:
+                    raise ValueError(
+                        f"Unknown retrieval strategy '{effective_strat}'. "
+                        f"Known strategies: {sorted(RETRIEVAL_STRATEGIES.keys())}."
+                    )
+                if query_contour_id is not None and not is_region_based_strategy(effective_strat):
+                    raise ValueError(
+                        f"Retrieval strategy '{effective_strat}' does not accept query_contour_id; "
+                        "query_contour_id is only accepted for region-based retrieval strategies."
+                    )
             emb_kinds = contract.conditioning.embedding_kinds or ["image_cls"]
             if query_contour_id is not None and "region_mean" not in emb_kinds:
                 raise ValueError(

--- a/app/services/inference/input_validator.py
+++ b/app/services/inference/input_validator.py
@@ -217,13 +217,35 @@ def validate_and_normalize_inputs(
 
         if cond_kind == "instances":
             if strategy is not None:
-                raise ValueError("Conditioning kind 'instances' does not accept a retrieval strategy.")
-            if query_contour_id is not None:
-                raise ValueError("Conditioning kind 'instances' does not accept query_contour_id.")
+                effective_strat = strategy
+                from app.services.exemplar_retrieval import (
+                    RETRIEVAL_STRATEGIES,
+                    is_region_based_strategy,
+                )
+                if effective_strat not in RETRIEVAL_STRATEGIES:
+                    raise ValueError(
+                        f"Unknown retrieval strategy '{effective_strat}'. "
+                        f"Known strategies: {sorted(RETRIEVAL_STRATEGIES.keys())}."
+                    )
+                if query_contour_id is not None and not is_region_based_strategy(effective_strat):
+                    raise ValueError(
+                        f"Retrieval strategy '{effective_strat}' does not accept query_contour_id; "
+                        "query_contour_id is only accepted for region-based retrieval strategies."
+                    )
+            elif query_contour_id is not None:
+                raise ValueError("Conditioning kind 'instances' without a retrieval strategy does not accept query_contour_id.")
 
         elif cond_kind == "reference_images":
             effective_strat = strategy or "global_scene"
-            from app.services.exemplar_retrieval import is_region_based_strategy
+            from app.services.exemplar_retrieval import (
+                RETRIEVAL_STRATEGIES,
+                is_region_based_strategy,
+            )
+            if effective_strat not in RETRIEVAL_STRATEGIES:
+                raise ValueError(
+                    f"Unknown retrieval strategy '{effective_strat}'. "
+                    f"Known strategies: {sorted(RETRIEVAL_STRATEGIES.keys())}."
+                )
             if query_contour_id is not None and not is_region_based_strategy(effective_strat):
                 raise ValueError(
                     f"Retrieval strategy '{effective_strat}' does not accept query_contour_id; "

--- a/app/services/inference/input_validator.py
+++ b/app/services/inference/input_validator.py
@@ -1,0 +1,257 @@
+"""Generic inference input validator and normalizer (Issue #27).
+
+Validates submitted inference inputs against a model's effective InputContract,
+filling defaults, validating types, ranges, options, and enforcing conditioning
+cardinality bounds and semantics.
+"""
+from __future__ import annotations
+
+import math
+from typing import Any
+
+from iquana_toolbox.schemas.input_contract import InputContract
+
+
+def validate_and_normalize_inputs(
+    contract: InputContract,
+    raw_inputs: dict[str, Any] | None,
+) -> dict[str, Any]:
+    """Validate and normalize inference inputs against an :class:`InputContract`.
+
+    Args:
+        contract: The effective InputContract for the selected model and task.
+        raw_inputs: Generic inputs dictionary containing "conditioning" and/or "parameters",
+            or None.
+
+    Returns:
+        A canonical normalized dictionary:
+        {
+            "conditioning": {
+                "count": int,
+                "strategy": str | None,
+                "concept_text": str | None,
+            },
+            "parameters": { ... }
+        }
+
+    Raises:
+        ValueError: If input structure, parameter types, bounds, options, or conditioning
+            cardinalities violate the contract.
+    """
+    if raw_inputs is None:
+        raw_inputs = {}
+
+    if not isinstance(raw_inputs, dict):
+        raise ValueError(f"inputs must be a dictionary, got {type(raw_inputs).__name__}")
+
+    # Reject unknown top-level envelope keys
+    allowed_top_level = {"conditioning", "parameters"}
+    unknown_top_level = set(raw_inputs.keys()) - allowed_top_level
+    if unknown_top_level:
+        raise ValueError(
+            f"Unknown keys in inputs envelope: {sorted(unknown_top_level)}. "
+            f"Allowed keys: {sorted(allowed_top_level)}"
+        )
+
+    raw_params = raw_inputs.get("parameters")
+    if raw_params is None:
+        raw_params = {}
+    elif not isinstance(raw_params, dict):
+        raise ValueError(f"parameters must be a dictionary, got {type(raw_params).__name__}")
+
+    raw_cond = raw_inputs.get("conditioning")
+    if raw_cond is None:
+        raw_cond = {}
+    elif not isinstance(raw_cond, dict):
+        raise ValueError(f"conditioning must be a dictionary, got {type(raw_cond).__name__}")
+
+    # Reject unknown conditioning keys
+    allowed_cond_keys = {"count", "strategy", "concept_text", "query_contour_id"}
+    unknown_cond_keys = set(raw_cond.keys()) - allowed_cond_keys
+    if unknown_cond_keys:
+        raise ValueError(
+            f"Unknown conditioning keys: {sorted(unknown_cond_keys)}. "
+            f"Allowed keys: {sorted(allowed_cond_keys)}"
+        )
+
+    # ----------------------------------------------------------------------- #
+    # 1. Parameter validation and default normalization
+    # ----------------------------------------------------------------------- #
+    declared_by_key = {p.key: p for p in contract.parameters}
+
+    # Reject unknown parameter keys
+    unknown_params = set(raw_params.keys()) - set(declared_by_key.keys())
+    if unknown_params:
+        raise ValueError(
+            f"Unknown parameter(s) {sorted(unknown_params)} for task '{contract.task}'. "
+            f"Declared parameters: {sorted(declared_by_key.keys())}"
+        )
+
+    normalized_parameters: dict[str, Any] = {}
+    for key, spec in declared_by_key.items():
+        if key in raw_params and raw_params[key] is not None:
+            val = raw_params[key]
+        else:
+            val = spec.default_value
+
+        spec_type = spec.type
+        if spec_type == "bool":
+            if not isinstance(val, bool):
+                raise ValueError(
+                    f"Parameter '{key}' must be a bool, got {type(val).__name__} ({val!r})"
+                )
+            normalized_val: Any = bool(val)
+        elif spec_type == "int":
+            if isinstance(val, bool) or not isinstance(val, int):
+                raise ValueError(
+                    f"Parameter '{key}' must be an int, got {type(val).__name__} ({val!r})"
+                )
+            normalized_val = int(val)
+        elif spec_type == "float":
+            if isinstance(val, bool) or not isinstance(val, (int, float)) or not math.isfinite(val):
+                raise ValueError(
+                    f"Parameter '{key}' must be a finite float, got {type(val).__name__} ({val!r})"
+                )
+            normalized_val = float(val)
+        elif spec_type == "str":
+            if not isinstance(val, str):
+                raise ValueError(
+                    f"Parameter '{key}' must be a str, got {type(val).__name__} ({val!r})"
+                )
+            normalized_val = str(val)
+        else:
+            raise ValueError(f"Unsupported parameter type '{spec_type}' for '{key}'")
+
+        if spec.options is not None:
+            if normalized_val not in spec.options:
+                raise ValueError(
+                    f"Parameter '{key}' value {normalized_val!r} is not in allowed options: {spec.options}"
+                )
+
+        if spec_type in {"int", "float"}:
+            if spec.min_value is not None and normalized_val < spec.min_value:
+                raise ValueError(
+                    f"Parameter '{key}' value {normalized_val} is less than min_value {spec.min_value}"
+                )
+            if spec.max_value is not None and normalized_val > spec.max_value:
+                raise ValueError(
+                    f"Parameter '{key}' value {normalized_val} is greater than max_value {spec.max_value}"
+                )
+
+        normalized_parameters[key] = normalized_val
+
+    # ----------------------------------------------------------------------- #
+    # 2. Conditioning validation and normalization
+    # ----------------------------------------------------------------------- #
+    cond_kind = contract.conditioning.kind
+    normalized_conditioning: dict[str, Any]
+
+    query_contour_id = raw_cond.get("query_contour_id")
+    if query_contour_id is not None:
+        if isinstance(query_contour_id, bool) or not isinstance(query_contour_id, int):
+            raise ValueError(
+                f"query_contour_id must be an integer, got {type(query_contour_id).__name__}"
+            )
+
+    if cond_kind == "none":
+        if raw_cond.get("strategy") is not None:
+            raise ValueError("Conditioning kind 'none' does not accept a retrieval strategy.")
+        if raw_cond.get("concept_text") is not None:
+            raise ValueError("Conditioning kind 'none' does not accept concept_text.")
+        if query_contour_id is not None:
+            raise ValueError("Conditioning kind 'none' does not accept query_contour_id.")
+        count_val = raw_cond.get("count")
+        if count_val is not None and count_val != 0:
+            raise ValueError(f"Conditioning kind 'none' does not accept count > 0 (got {count_val}).")
+        normalized_conditioning = {
+            "count": 0,
+            "strategy": None,
+            "concept_text": None,
+            "query_contour_id": None,
+        }
+
+    elif cond_kind == "concept_text":
+        if raw_cond.get("strategy") is not None:
+            raise ValueError("Conditioning kind 'concept_text' does not accept a retrieval strategy.")
+        if query_contour_id is not None:
+            raise ValueError("Conditioning kind 'concept_text' does not accept query_contour_id.")
+        count_val = raw_cond.get("count")
+        if count_val is not None and count_val != 0:
+            raise ValueError(f"Conditioning kind 'concept_text' does not accept count > 0 (got {count_val}).")
+        text = raw_cond.get("concept_text")
+        if text is not None and not isinstance(text, str):
+            raise ValueError(f"concept_text must be a string, got {type(text).__name__}")
+        normalized_conditioning = {
+            "count": 0,
+            "strategy": None,
+            "concept_text": text,
+            "query_contour_id": None,
+        }
+
+    else:  # instances, reference_images, embeddings
+        # Validate count
+        raw_count = raw_cond.get("count")
+        if raw_count is None:
+            # Default to min_units (or 1 if min_units is 0/None)
+            count = contract.conditioning.min_units if contract.conditioning.min_units > 0 else 1
+        else:
+            if isinstance(raw_count, bool) or not isinstance(raw_count, int):
+                raise ValueError(f"Conditioning count must be an integer, got {type(raw_count).__name__}")
+            count = raw_count
+
+        if count < contract.conditioning.min_units:
+            raise ValueError(
+                f"Conditioning count {count} is below min_units {contract.conditioning.min_units} "
+                f"for task '{contract.task}'."
+            )
+        if contract.conditioning.max_units is not None and count > contract.conditioning.max_units:
+            raise ValueError(
+                f"Conditioning count {count} exceeds max_units {contract.conditioning.max_units} "
+                f"for task '{contract.task}'."
+            )
+
+        # Validate strategy
+        strategy = raw_cond.get("strategy")
+        if strategy is not None and not isinstance(strategy, str):
+            raise ValueError(f"retrieval strategy must be a string, got {type(strategy).__name__}")
+
+        if cond_kind == "instances":
+            if strategy is not None:
+                raise ValueError("Conditioning kind 'instances' does not accept a retrieval strategy.")
+            if query_contour_id is not None:
+                raise ValueError("Conditioning kind 'instances' does not accept query_contour_id.")
+
+        elif cond_kind == "reference_images":
+            effective_strat = strategy or "global_scene"
+            from app.services.exemplar_retrieval import is_region_based_strategy
+            if query_contour_id is not None and not is_region_based_strategy(effective_strat):
+                raise ValueError(
+                    f"Retrieval strategy '{effective_strat}' does not accept query_contour_id; "
+                    "query_contour_id is only accepted for region-based retrieval strategies."
+                )
+
+        elif cond_kind == "embeddings":
+            if strategy is not None:
+                raise ValueError("Conditioning kind 'embeddings' does not accept a retrieval strategy.")
+            emb_kinds = contract.conditioning.embedding_kinds or ["image_cls"]
+            if query_contour_id is not None and "region_mean" not in emb_kinds:
+                raise ValueError(
+                    "Embedding conditioning without 'region_mean' does not accept query_contour_id."
+                )
+
+        # Validate concept_text if provided
+        concept_text = raw_cond.get("concept_text")
+        if concept_text is not None and not isinstance(concept_text, str):
+            raise ValueError(f"concept_text must be a string, got {type(concept_text).__name__}")
+
+        normalized_conditioning = {
+            "count": count,
+            "strategy": strategy,
+            "concept_text": concept_text,
+            "query_contour_id": query_contour_id,
+        }
+
+    return {
+        "conditioning": normalized_conditioning,
+        "parameters": normalized_parameters,
+    }

--- a/app/services/inference/planning.py
+++ b/app/services/inference/planning.py
@@ -298,7 +298,8 @@ def resolve_steps(
                     raw_cond["count"] = cond.max_units or cond.min_units or 1
 
             raw_params: dict[str, Any] = {}
-            if step.min_confidence is not None and step.min_confidence > 0.0:
+            declared_param_keys = {p.key for p in option.input_contract.parameters}
+            if "threshold" in declared_param_keys and step.min_confidence is not None and step.min_confidence > 0.0:
                 raw_params["threshold"] = step.min_confidence
             raw_inputs = {"conditioning": raw_cond, "parameters": raw_params}
 

--- a/app/services/inference/planning.py
+++ b/app/services/inference/planning.py
@@ -278,31 +278,7 @@ def resolve_steps(
                 f"Model {option.name!r} does not predict label {label.name!r}; it predicts "
                 f"label ids {sorted(option.label_ids)}.",
             )
-        # Extract inputs or synthesize from legacy request fields
-        raw_inputs = step.inputs
-        if raw_inputs is None:
-            raw_cond: dict[str, Any] = {}
-            if step.task == "cross-image-suggestion":
-                if step.retrieval_strategy is not None:
-                    raw_cond["strategy"] = step.retrieval_strategy
-                cond = option.input_contract.conditioning
-                top_k = step.top_k if step.top_k is not None else 5
-                if cond.user_selectable_count:
-                    count = top_k
-                    if cond.max_units is not None:
-                        count = min(count, cond.max_units)
-                    if cond.min_units is not None:
-                        count = max(count, cond.min_units)
-                    raw_cond["count"] = count
-                elif cond.kind in ("reference_images", "instances", "embeddings"):
-                    raw_cond["count"] = cond.max_units or cond.min_units or 1
-
-            raw_params: dict[str, Any] = {}
-            declared_param_keys = {p.key for p in option.input_contract.parameters}
-            if "threshold" in declared_param_keys and step.min_confidence is not None and step.min_confidence > 0.0:
-                raw_params["threshold"] = step.min_confidence
-            raw_inputs = {"conditioning": raw_cond, "parameters": raw_params}
-
+        raw_inputs = step.inputs if step.inputs is not None else {"conditioning": {}, "parameters": {}}
         try:
             normalized_inputs = validate_and_normalize_inputs(option.input_contract, raw_inputs)
         except ValueError as exc:
@@ -324,8 +300,6 @@ def resolve_steps(
             input_contract=option.input_contract,
             provenance=option.provenance,
             min_confidence=step.min_confidence,
-            retrieval_strategy=step.retrieval_strategy,
-            top_k=step.top_k,
         ))
 
     resolved.sort(key=lambda step: (step.level, step.label_name.lower()))

--- a/app/services/inference/planning.py
+++ b/app/services/inference/planning.py
@@ -43,6 +43,8 @@ from app.schemas.inference import (
     WriteMode,
 )
 from app.services.exemplar_retrieval import strategy_options
+from app.services.inference.contract_resolver import resolve_input_contract
+from app.services.inference.input_validator import validate_and_normalize_inputs
 from app.services.model_registry import list_available_models
 
 logger = getLogger(__name__)
@@ -94,8 +96,9 @@ def model_catalog(db: Session, dataset_id: int) -> ModelCatalog:
     which means class-agnostic: it may be bound to any label, and whatever it returns is
     labelled with that step's label.
 
-    Cross-image models are only offered when at least one retrieval strategy is actually
-    available -- without a populated embedding store they would fail on every image.
+    Cross-image models requiring exemplar retrieval are only offered when at least one retrieval
+    strategy is actually available. Models with self-contained or concept-text conditioning remain
+    available even without embeddings.
     """
     dataset_labels = _dataset_label_ids(db, dataset_id)
     # Scoped to this dataset: a strategy that ranks by visual similarity is only listed
@@ -106,14 +109,32 @@ def model_catalog(db: Session, dataset_id: int) -> ModelCatalog:
 
     options: list[ModelOption] = []
     for task in BATCH_TASKS:
-        if task == "cross-image-suggestion" and not cross_image_usable:
-            continue
         try:
             listing = list_available_models(task)
         except Exception:
             logger.exception("Could not list %s models; the picker will omit them.", task)
             continue
         for info in listing.get("result", []):
+            try:
+                contract, provenance = resolve_input_contract(info, task)
+            except Exception:
+                logger.exception(
+                    "Failed to resolve input contract for model '%s', task '%s'; omitting model.",
+                    info.get("name") or info.get("registry_key"),
+                    task,
+                )
+                continue
+
+            # If conditioning requires external exemplar retrieval (reference_images/embeddings/instances)
+            # and no retrieval strategies are usable, skip offering this option.
+            # Models with 'none' or 'concept_text' conditioning are always included regardless of embeddings.
+            if (
+                task == "cross-image-suggestion"
+                and not cross_image_usable
+                and contract.conditioning.kind in {"reference_images", "embeddings", "instances"}
+            ):
+                continue
+
             label_ids = [int(lid) for lid in info.get("label_ids") or []]
             options.append(ModelOption(
                 registry_key=info.get("registry_key") or info.get("name"),
@@ -126,6 +147,8 @@ def model_catalog(db: Session, dataset_id: int) -> ModelCatalog:
                 label_ids=label_ids,
                 # A model whose classes are labels of this dataset was fine-tuned on it.
                 trained_on_dataset=bool(label_ids) and bool(set(label_ids) & dataset_labels),
+                input_contract=contract,
+                provenance=provenance,
             ))
 
     options.sort(key=lambda option: (not option.trained_on_dataset, option.name.lower()))
@@ -255,13 +278,53 @@ def resolve_steps(
                 f"Model {option.name!r} does not predict label {label.name!r}; it predicts "
                 f"label ids {sorted(option.label_ids)}.",
             )
+        # Extract inputs or synthesize from legacy request fields
+        raw_inputs = step.inputs
+        if raw_inputs is None:
+            raw_cond: dict[str, Any] = {}
+            if step.task == "cross-image-suggestion":
+                if step.retrieval_strategy is not None:
+                    raw_cond["strategy"] = step.retrieval_strategy
+                cond = option.input_contract.conditioning
+                top_k = step.top_k if step.top_k is not None else 5
+                if cond.user_selectable_count:
+                    count = top_k
+                    if cond.max_units is not None:
+                        count = min(count, cond.max_units)
+                    if cond.min_units is not None:
+                        count = max(count, cond.min_units)
+                    raw_cond["count"] = count
+                elif cond.kind in ("reference_images", "instances", "embeddings"):
+                    raw_cond["count"] = cond.max_units or cond.min_units or 1
+
+            raw_params: dict[str, Any] = {}
+            if step.min_confidence is not None and step.min_confidence > 0.0:
+                raw_params["threshold"] = step.min_confidence
+            raw_inputs = {"conditioning": raw_cond, "parameters": raw_params}
+
+        try:
+            normalized_inputs = validate_and_normalize_inputs(option.input_contract, raw_inputs)
+        except ValueError as exc:
+            raise HTTPException(
+                status.HTTP_400_BAD_REQUEST,
+                f"Invalid inference inputs for model {option.name!r} (task '{step.task}'): {exc}",
+            ) from exc
+
         resolved.append(ResolvedStep(
-            **step.model_dump(),
+            label_id=step.label_id,
+            model_registry_key=step.model_registry_key,
+            task=step.task,
             level=levels[step.label_id],
             parent_label_id=label.parent_id,
             label_name=label.name,
             model_name=option.name,
             model_label_ids=list(option.label_ids),
+            inputs=normalized_inputs,
+            input_contract=option.input_contract,
+            provenance=option.provenance,
+            min_confidence=step.min_confidence,
+            retrieval_strategy=step.retrieval_strategy,
+            top_k=step.top_k,
         ))
 
     resolved.sort(key=lambda step: (step.level, step.label_name.lower()))

--- a/app/services/model_registry.py
+++ b/app/services/model_registry.py
@@ -187,12 +187,23 @@ def _full_model_info(registry_key: str) -> dict:
                 metadata["description"] = reg_model.description
             if reg_model.tags:
                 if "input_contracts" in reg_model.tags:
+                    registered_contracts_tag = reg_model.tags["input_contracts"]
+                    # Keep the registered-model tag authoritative even when it is malformed.
+                    # The contract resolver handles the error per model; retaining the raw tag
+                    # prevents stale artifact metadata from silently becoming effective.
+                    _set_model_tag(metadata, "input_contracts", registered_contracts_tag)
                     try:
-                        parsed_contracts = json.loads(reg_model.tags["input_contracts"])
+                        parsed_contracts = (
+                            json.loads(registered_contracts_tag)
+                            if isinstance(registered_contracts_tag, str)
+                            else registered_contracts_tag
+                        )
                         if parsed_contracts is not None:
                             metadata["input_contracts"] = parsed_contracts
+                        else:
+                            metadata.pop("input_contracts", None)
                     except Exception:
-                        pass
+                        metadata.pop("input_contracts", None)
                 if not metadata.get("name"):
                     metadata["name"] = reg_model.name
                 if not metadata.get("registry_key"):

--- a/app/services/model_registry.py
+++ b/app/services/model_registry.py
@@ -154,17 +154,17 @@ def _models_for_task(task: str):
 
 
 def _full_model_info(registry_key: str) -> dict:
-    """Return a model's complete ``model_info`` from its artifact metadata.
+    """Return a model's complete ``model_info`` from its artifact metadata and registered-model tags.
 
     ``register_model`` stores the full ``ModelInfo.model_dump()`` as the logged
-    model's ``metadata`` (recorded in the MLmodel file, not the weights), so
-    reading it back is lossless and cheap -- ~50ms regardless of model size, and
-    independent of toolbox version. This is preferable to rebuilding the info
-    from the registered-model tags, which only carry the filterable subset
-    (task/status/...) and drop free-text fields like description and usage_tip.
+    model's ``metadata`` (recorded in the MLmodel file, not the weights), and
+    synchronizes ``input_contracts`` and ``description`` into registered-model tags.
+    Merging registered-model tags ensures newly added/updated contracts are
+    discovered immediately without requiring artifact re-logging.
 
     Falls back to a minimal stub if an older artifact carries no metadata.
     """
+    metadata: dict = {}
     try:
         info = mlflow.models.get_model_info(f"models:/{registry_key}/latest")
         if info.metadata:
@@ -176,10 +176,34 @@ def _full_model_info(registry_key: str) -> dict:
                     dict(tag) if isinstance(tag, dict) else tag
                     for tag in metadata["tags"]
                 ]
-            return _enrich_model_provenance(metadata)
-        logger.warning("Model '%s' has no artifact metadata; returning stub.", registry_key)
     except Exception:
-        logger.exception("Failed to read artifact metadata for model '%s'.", registry_key)
+        logger.debug("Failed to read artifact metadata for model '%s'.", registry_key)
+
+    # Merge registered model tags so synchronized contracts and descriptions are always seen
+    try:
+        reg_model = MODEL_REGISTRY.client.get_registered_model(registry_key)
+        if reg_model:
+            if reg_model.description:
+                metadata["description"] = reg_model.description
+            if reg_model.tags:
+                if "input_contracts" in reg_model.tags:
+                    try:
+                        parsed_contracts = json.loads(reg_model.tags["input_contracts"])
+                        if parsed_contracts is not None:
+                            metadata["input_contracts"] = parsed_contracts
+                    except Exception:
+                        pass
+                if not metadata.get("name"):
+                    metadata["name"] = reg_model.name
+                if not metadata.get("registry_key"):
+                    metadata["registry_key"] = reg_model.name
+    except Exception:
+        logger.debug("Failed to read registered model tags for '%s'.", registry_key)
+
+    if metadata:
+        return _enrich_model_provenance(metadata)
+
+    logger.warning("Model '%s' has no artifact metadata; returning stub.", registry_key)
     return {"registry_key": registry_key, "name": registry_key}
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ dependencies = [
 ]
 
 [tool.uv.sources]
-iquana-toolbox = { git = "https://github.com/Iquana-tool/iquana-toolbox.git" }
+iquana-toolbox = { git = "https://github.com/shivamtawari/iquana-toolbox.git", rev = "ffe891d7a2e9260400654d777f34e44ba4b745bf" }
 # iquana-toolbox pulls in torch transitively. This backend never runs model
 # inference itself (that's the separate ai-service, over AI_SERVICE_URL) and
 # no code here imports torch directly, so the CUDA build is pure dead weight:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ dependencies = [
 ]
 
 [tool.uv.sources]
-iquana-toolbox = { git = "https://github.com/shivamtawari/iquana-toolbox.git", rev = "ffe891d7a2e9260400654d777f34e44ba4b745bf" }
+iquana-toolbox = { git = "https://github.com/Iquana-tool/iquana-toolbox.git", rev = "425a08aaed1f23a7f98aa0680eb7ae2d7af40a21" }
 # iquana-toolbox pulls in torch transitively. This backend never runs model
 # inference itself (that's the separate ai-service, over AI_SERVICE_URL) and
 # no code here imports torch directly, so the CUDA build is pure dead weight:

--- a/tests/test_batch_inference.py
+++ b/tests/test_batch_inference.py
@@ -477,13 +477,16 @@ def test_preserve_reviewed_spares_approved_objects_and_their_subtree(ctx):
 
 
 # --------------------------------------------------------------------------- #
-# Stubs
-# --------------------------------------------------------------------------- #
+from app.services.inference.contract_resolver import LEGACY_TASK_DEFAULTS
+
+
 def _stub_catalog(monkeypatch, ctx, label_ids=()):
     """Pretend one ready instance-segmentation model exists, without touching MLflow."""
+    contract = LEGACY_TASK_DEFAULTS["instance-segmentation"]
     monkeypatch.setattr(planning, "model_catalog", lambda db, dataset_id: ModelCatalog(
         models=[ModelOption(registry_key="m2f", name="Mask2Former",
-                            task="instance-segmentation", label_ids=list(label_ids))],
+                            task="instance-segmentation", label_ids=list(label_ids),
+                            input_contract=contract, provenance="legacy_default")],
     ))
 
 

--- a/tests/test_conditioning_dispatcher.py
+++ b/tests/test_conditioning_dispatcher.py
@@ -145,11 +145,11 @@ def test_resolve_reference_images_enforces_completeness_and_max_units(world):
         model_id=MODEL,
     )
     # Only `near` image is selected (since mid is incomplete, and far is second choice)
-    # With max_images=1, only the top exemplar from the selected reference image is materialized
-    assert len(exemplars) == 1
-    assert exemplars[0].image_url == "/data/near.png"
-    assert len(matches) == 1
-    assert matches[0].contour_id in {c_near1.id, c_near2.id}
+    # Both concept exemplars from the selected reference image are materialized so all objects are prompted
+    assert len(exemplars) == 2
+    assert {ex.image_url for ex in exemplars} == {"/data/near.png"}
+    assert len(matches) == 2
+    assert {m.contour_id for m in matches} == {c_near1.id, c_near2.id}
 
     # 2. With complete annotation NOT required:
     exemplars_any, matches_any = resolve_reference_images(
@@ -162,7 +162,8 @@ def test_resolve_reference_images_enforces_completeness_and_max_units(world):
         requires_complete_annotation=False,
         model_id=MODEL,
     )
-    # Both near and mid selected
+    # Both near (2 contours) and mid (1 contour) selected -> 3 exemplars across 2 images
+    assert len(exemplars_any) == 3
     urls = {ex.image_url for ex in exemplars_any}
     assert urls == {"/data/near.png", "/data/mid.png"}
 
@@ -517,6 +518,80 @@ def test_dispatch_conditioning_region_mean_deterministic_ordering_fallback(world
     res = dispatch_conditioning(s, step, world["target"])
     # Deterministic order by id / created_at selects c_newer
     assert res["vectors"]["region_mean"] == v_newer
+
+
+def test_dispatch_conditioning_in_context_exemplar_vectors(world):
+    """In-context embedding conditioning retrieves count exemplar vectors from other images."""
+    s = world["session"]
+    c_near = _contour(s, world["near_mask"].id, label_id=world["label"].id)
+    c_far = _contour(s, world["far_mask"].id, label_id=world["label"].id)
+    v_near = _axis((0, 0.4), (1, 0.4))
+    v_far = _axis((0, 0.9), (1, 0.1))
+    upsert_embedding(s, contour_id=c_near.id, kind="region_mean", model_id=MODEL, vector=v_near)
+    upsert_embedding(s, contour_id=c_far.id, kind="region_mean", model_id=MODEL, vector=v_far)
+
+    # In-context embedding model with user-selectable count = 2
+    step_incontext_emb = ResolvedStep(
+        label_id=world["label"].id,
+        model_registry_key="prototype_model",
+        task="cross-image-suggestion",
+        level=0,
+        label_name="coral",
+        model_name="PrototypeModel",
+        inputs={"conditioning": {"count": 2, "strategy": "concept_annotations"}, "parameters": {}},
+        input_contract=InputContract(
+            task="cross-image-suggestion",
+            conditioning=ConditioningSpec(
+                kind="embeddings",
+                unit="vector",
+                embedding_kinds=["region_mean"],
+                min_units=1,
+                max_units=5,
+                user_selectable_count=True,
+            ),
+            parameters=[],
+        ),
+    )
+    res = dispatch_conditioning(s, step_incontext_emb, world["target"])
+    assert res["kind"] == "embeddings"
+    assert len(res["exemplar_vectors"]) == 2
+    assert len(res["contour_ids"]) == 2
+    assert set(res["contour_ids"]) == {c_near.id, c_far.id}
+    assert res["concept"] is not None
+    assert res["concept"].name == "coral"
+    assert len(res["vectors"]["region_mean"]) == 2
+
+
+def test_dispatch_conditioning_in_context_min_units_enforced(world):
+    """In-context embedding conditioning raises when fewer than min_units exemplar vectors exist."""
+    s = world["session"]
+    c_near = _contour(s, world["near_mask"].id, label_id=world["label"].id)
+    upsert_embedding(s, contour_id=c_near.id, kind="region_mean", model_id=MODEL, vector=_axis((0, 0.5)))
+
+    # Contract requires min_units=2, but only 1 contour has an embedding
+    step_incontext_emb_min2 = ResolvedStep(
+        label_id=world["label"].id,
+        model_registry_key="prototype_model",
+        task="cross-image-suggestion",
+        level=0,
+        label_name="coral",
+        model_name="PrototypeModel",
+        inputs={"conditioning": {"count": 2}, "parameters": {}},
+        input_contract=InputContract(
+            task="cross-image-suggestion",
+            conditioning=ConditioningSpec(
+                kind="embeddings",
+                unit="vector",
+                embedding_kinds=["region_mean"],
+                min_units=2,
+                max_units=5,
+                user_selectable_count=True,
+            ),
+            parameters=[],
+        ),
+    )
+    with pytest.raises(ValueError, match="Resolved 1 exemplar vector.*requires at least 2 min_units"):
+        dispatch_conditioning(s, step_incontext_emb_min2, world["target"])
 
 
 def test_dispatch_conditioning_missing_embedding_raises(world):
@@ -984,3 +1059,61 @@ def test_predict_cross_image_runs_with_empty_optional_conditioning(world, monkey
     assert _predict_cross_image(world["session"], step, world["target"], "u") == []
     assert len(captured_requests) == 1
     assert captured_requests[0].exemplars == []
+
+
+def test_predict_cross_image_in_context_embeddings_real_request(world, monkeypatch):
+    """Real CrossImageSuggestionRequest validates and serializes in-context exemplar embeddings."""
+    from app.services.inference.execution import _predict_cross_image
+    from iquana_toolbox.schemas.networking.http.services import CrossImageSuggestionRequest
+
+    s = world["session"]
+    c_near = _contour(s, world["near_mask"].id, label_id=world["label"].id)
+    c_far = _contour(s, world["far_mask"].id, label_id=world["label"].id)
+    v_near = _axis((0, 0.4), (1, 0.4))
+    v_far = _axis((0, 0.9), (1, 0.1))
+    upsert_embedding(s, contour_id=c_near.id, kind="region_mean", model_id=MODEL, vector=v_near)
+    upsert_embedding(s, contour_id=c_far.id, kind="region_mean", model_id=MODEL, vector=v_far)
+
+    captured_requests = []
+
+    class MockCrossImageService:
+        async def inference(self, request):
+            assert isinstance(request, CrossImageSuggestionRequest)
+            captured_requests.append(request)
+            return []
+
+    monkeypatch.setattr(
+        "app.services.ai_services.cross_image.CrossImageService",
+        lambda: MockCrossImageService(),
+    )
+
+    step = ResolvedStep(
+        label_id=world["label"].id,
+        model_registry_key="emb-incontext-model",
+        task="cross-image-suggestion",
+        level=0,
+        label_name="coral",
+        model_name="Embedding in-context model",
+        inputs={
+            "conditioning": {"count": 2, "strategy": "concept_annotations"},
+            "parameters": {},
+        },
+        input_contract=InputContract(
+            task="cross-image-suggestion",
+            conditioning=ConditioningSpec(
+                kind="embeddings",
+                unit="vector",
+                embedding_kinds=["region_mean"],
+                min_units=1,
+                max_units=5,
+                user_selectable_count=True,
+            ),
+            parameters=[],
+        ),
+    )
+
+    result = _predict_cross_image(s, step, world["target"], "alice")
+    assert result == []
+    assert len(captured_requests) == 1
+    req = captured_requests[0]
+    assert req.exemplar_embeddings["region_mean"] == [v_far, v_near]

--- a/tests/test_conditioning_dispatcher.py
+++ b/tests/test_conditioning_dispatcher.py
@@ -311,6 +311,59 @@ def test_dispatch_conditioning_all_kinds(world):
     assert res_emb["vector"] is not None
 
 
+def test_dispatch_strategy_count_skips_multiple_target_matches(world):
+    """A count-one region strategy widens past multiple target contours to find an external match."""
+    s = world["session"]
+    target_contour_1 = _contour(s, world["target_mask"].id, label_id=world["label"].id)
+    target_contour_2 = _contour(s, world["target_mask"].id, label_id=world["label"].id)
+    external_contour = _contour(s, world["near_mask"].id, label_id=world["label"].id)
+    query_vector = _axis((0, 1.0))
+    upsert_embedding(
+        s, contour_id=target_contour_1.id, kind="region_mean", model_id=MODEL, vector=query_vector
+    )
+    upsert_embedding(
+        s, contour_id=target_contour_2.id, kind="region_mean", model_id=MODEL, vector=query_vector
+    )
+    upsert_embedding(
+        s,
+        contour_id=external_contour.id,
+        kind="region_mean",
+        model_id=MODEL,
+        vector=_axis((0, 1.0), (1, 0.1)),
+    )
+
+    step = ResolvedStep(
+        label_id=world["label"].id,
+        model_registry_key="region-model",
+        task="instance-segmentation",
+        level=0,
+        label_name="coral",
+        model_name="Region model",
+        inputs={
+            "conditioning": {
+                "count": 1,
+                "strategy": "concept_region",
+                "query_contour_id": target_contour_1.id,
+            },
+            "parameters": {},
+        },
+        input_contract=InputContract(
+            task="instance-segmentation",
+            conditioning=ConditioningSpec(
+                kind="instances", unit="instance", min_units=1, max_units=5,
+                user_selectable_count=True,
+            ),
+            parameters=[],
+        ),
+    )
+
+    result = dispatch_conditioning(s, step, world["target"])
+
+    assert [match.contour_id for match in result["matches"]] == [external_contour.id]
+    assert result["contour_ids"] == [external_contour.id]
+    assert result["exemplars"][0].image_url == "/data/near.png"
+
+
 def test_dispatch_conditioning_unsupported_kind_raises(world):
     s = world["session"]
     step_bad = ResolvedStep(
@@ -542,6 +595,100 @@ def test_dispatch_conditioning_post_resolution_min_units_instances_raises(world)
         dispatch_conditioning(s, step_inst_min3, world["target"])
 
 
+def test_dispatch_conditioning_zero_count_is_empty_without_retrieval(world, monkeypatch):
+    """Optional conditioning count=0 must skip region query embedding and exemplar retrieval."""
+    s = world["session"]
+    _contour(s, world["near_mask"].id, label_id=world["label"].id)
+    query_contour = _contour(s, world["target_mask"].id, label_id=world["label"].id)
+
+    def unexpected_retrieval(*_args, **_kwargs):
+        pytest.fail("zero-count reference conditioning must not retrieve exemplars")
+
+    def unexpected_embedding(*_args, **_kwargs):
+        pytest.fail("zero-count reference conditioning must not resolve query embeddings")
+
+    monkeypatch.setattr(
+        "app.services.inference.conditioning_dispatcher.retrieve_exemplars",
+        unexpected_retrieval,
+    )
+    monkeypatch.setattr(
+        "app.services.inference.conditioning_dispatcher.get_embedding_vector",
+        unexpected_embedding,
+    )
+
+    reference_step = ResolvedStep(
+        label_id=world["label"].id,
+        model_registry_key="optional-reference-model",
+        task="cross-image-suggestion",
+        level=0,
+        label_name="coral",
+        model_name="Optional reference model",
+        inputs={
+            "conditioning": {
+                "count": 0,
+                "strategy": "concept_region",
+                "query_contour_id": query_contour.id,
+                "concept_text": None,
+            },
+            "parameters": {},
+        },
+        input_contract=InputContract(
+            task="cross-image-suggestion",
+            conditioning=ConditioningSpec(
+                kind="reference_images",
+                unit="image",
+                min_units=0,
+                max_units=5,
+                user_selectable_count=True,
+            ),
+            parameters=[],
+        ),
+    )
+    reference_result = dispatch_conditioning(s, reference_step, world["target"])
+    assert reference_result["kind"] == "reference_images"
+    assert reference_result["exemplars"] == []
+    assert reference_result["matches"] == []
+    assert reference_result["contour_ids"] == []
+    assert reference_result["positive_exemplars"] == []
+    assert reference_result["concept"].name == "coral"
+
+    instance_step = ResolvedStep(
+        label_id=world["label"].id,
+        model_registry_key="optional-instance-model",
+        task="instance-segmentation",
+        level=0,
+        label_name="coral",
+        model_name="Optional instance model",
+        inputs={
+            "conditioning": {"count": 0, "strategy": "global_scene", "concept_text": None},
+            "parameters": {},
+        },
+        input_contract=InputContract(
+            task="instance-segmentation",
+            conditioning=ConditioningSpec(
+                kind="instances",
+                unit="instance",
+                min_units=0,
+                max_units=5,
+                user_selectable_count=True,
+            ),
+            parameters=[],
+        ),
+    )
+    instance_result = dispatch_conditioning(s, instance_step, world["target"])
+    assert instance_result["contour_ids"] == []
+    assert instance_result["positive_exemplars"] == []
+    assert instance_result["exemplars"] == []
+
+    cids, positive_exemplars, source_aware_exemplars = resolve_instance_conditioning(
+        s,
+        dataset_id=world["ds"].id,
+        concept_label_id=world["label"].id,
+        max_instances=0,
+    )
+    assert (cids, positive_exemplars, source_aware_exemplars) == ([], [], [])
+
+
 def test_predict_cross_image_with_concept_text_and_parameters(world, monkeypatch):
     """Worker _predict_cross_image forwards concept_text, parameters, and conditioning to AI service."""
     from app.services.inference.execution import _predict_cross_image
@@ -606,6 +753,15 @@ def test_predict_instance_segmentation_forwards_parameters_and_conditioning(worl
         lambda: MockInstanceSegmentationService(),
     )
 
+    class CapturedRequest:
+        def __init__(self, **kwargs):
+            self.__dict__.update(kwargs)
+
+    monkeypatch.setattr(
+        "app.services.inference.execution.InstanceSegmentationRequest",
+        CapturedRequest,
+    )
+
     s = world["session"]
     c = _contour(s, world["near_mask"].id, label_id=world["label"].id)
 
@@ -638,6 +794,7 @@ def test_predict_instance_segmentation_forwards_parameters_and_conditioning(worl
     assert req.contour_ids == [c.id]
     assert req.model_registry_key == "sam2"
     assert len(req.positive_exemplars) == 1
+    assert len(req.exemplars) == 1
 
 
 def test_resolve_reference_images_progressive_search_exhaustion(world, monkeypatch):
@@ -690,6 +847,43 @@ def test_resolve_reference_images_progressive_search_exhaustion(world, monkeypat
     assert any(k > 1024 for k in calls)
 
 
+def test_resolve_reference_images_global_scene_widens_past_sparse_concept_window(world):
+    """Global-scene retrieval keeps searching when early ranked images have no concept match."""
+    s = world["session"]
+
+    # Keep the only concept exemplar outside the initial 64-image scene window.
+    for index in range(70):
+        distractor, _ = _image(s, world["ds"].id, f"distractor-{index}")
+        upsert_embedding(
+            s,
+            image_id=distractor.id,
+            kind="image_cls",
+            model_id=MODEL,
+            vector=_axis((0, 1.0), (1, 0.01)),
+        )
+    late, late_mask = _image(
+        s, world["ds"].id, "late-concept", fully_annotated=True
+    )
+    late_contour = _contour(s, late_mask.id, label_id=world["label"].id)
+    upsert_embedding(
+        s, image_id=late.id, kind="image_cls", model_id=MODEL, vector=_axis((1, 1.0))
+    )
+
+    exemplars, matches = resolve_reference_images(
+        s,
+        target_image_id=world["target"].id,
+        dataset_id=world["ds"].id,
+        strategy="global_scene",
+        concept_label_id=world["label"].id,
+        max_images=1,
+        requires_complete_annotation=True,
+        model_id=MODEL,
+    )
+
+    assert [match.contour_id for match in matches] == [late_contour.id]
+    assert [exemplar.image_url for exemplar in exemplars] == ["/data/late-concept.png"]
+
+
 def test_predict_cross_image_forwards_source_aware_exemplars_and_positive_exemplars(world, monkeypatch):
     """_predict_cross_image forwards exemplars, positive_exemplars, and contour_ids."""
     from app.services.inference.execution import _predict_cross_image
@@ -737,3 +931,56 @@ def test_predict_cross_image_forwards_source_aware_exemplars_and_positive_exempl
     assert req.exemplars[0].mask is not None
     assert len(req.positive_exemplars) == 1
     assert req.contour_ids == [c.id]
+
+
+def test_predict_cross_image_runs_with_empty_optional_conditioning(world, monkeypatch):
+    """Cross-image models with min_units=0 still receive an empty exemplar list."""
+    from app.services.inference.execution import _predict_cross_image
+
+    captured_requests = []
+
+    class MockCrossImageService:
+        async def inference(self, request):
+            captured_requests.append(request)
+            return {"result": []}
+
+    class CapturedRequest:
+        def __init__(self, **kwargs):
+            self.__dict__.update(kwargs)
+
+    monkeypatch.setattr(
+        "app.services.ai_services.cross_image.CrossImageService",
+        lambda: MockCrossImageService(),
+    )
+    monkeypatch.setattr(
+        "iquana_toolbox.schemas.networking.http.services.CrossImageSuggestionRequest",
+        CapturedRequest,
+    )
+
+    step = ResolvedStep(
+        label_id=world["label"].id,
+        model_registry_key="optional-cross-model",
+        task="cross-image-suggestion",
+        level=0,
+        label_name="coral",
+        model_name="Optional cross model",
+        inputs={
+            "conditioning": {"count": 0, "strategy": None, "concept_text": None},
+            "parameters": {},
+        },
+        input_contract=InputContract(
+            task="cross-image-suggestion",
+            conditioning=ConditioningSpec(
+                kind="instances",
+                unit="instance",
+                min_units=0,
+                max_units=5,
+                user_selectable_count=True,
+            ),
+            parameters=[],
+        ),
+    )
+
+    assert _predict_cross_image(world["session"], step, world["target"], "u") == []
+    assert len(captured_requests) == 1
+    assert captured_requests[0].exemplars == []

--- a/tests/test_conditioning_dispatcher.py
+++ b/tests/test_conditioning_dispatcher.py
@@ -145,10 +145,11 @@ def test_resolve_reference_images_enforces_completeness_and_max_units(world):
         model_id=MODEL,
     )
     # Only `near` image is selected (since mid is incomplete, and far is second choice)
-    assert len(exemplars) == 2  # c_near1 and c_near2
-    assert all(ex.image_url == "/data/near.png" for ex in exemplars)
-    assert len(matches) == 2
-    assert {m.contour_id for m in matches} == {c_near1.id, c_near2.id}
+    # With max_images=1, only the top exemplar from the selected reference image is materialized
+    assert len(exemplars) == 1
+    assert exemplars[0].image_url == "/data/near.png"
+    assert len(matches) == 1
+    assert matches[0].contour_id in {c_near1.id, c_near2.id}
 
     # 2. With complete annotation NOT required:
     exemplars_any, matches_any = resolve_reference_images(
@@ -171,14 +172,18 @@ def test_resolve_instances(world):
     c1 = _contour(s, world["near_mask"].id, label_id=world["label"].id)
     c2 = _contour(s, world["far_mask"].id, label_id=world["label"].id)
 
-    cids = resolve_instance_conditioning(
+    cids, positive_exemplars, cross_image_exemplars = resolve_instance_conditioning(
         s,
         dataset_id=world["ds"].id,
         concept_label_id=world["label"].id,
         max_instances=1,
     )
     assert len(cids) == 1
+    assert len(positive_exemplars) == 1
+    assert len(cross_image_exemplars) == 1
     assert cids[0] in {c1.id, c2.id}
+    assert cross_image_exemplars[0].image_url in {"/data/near.png", "/data/far.png"}
+    assert cross_image_exemplars[0].mask is not None
 
 
 def test_resolve_embeddings(world):
@@ -632,3 +637,103 @@ def test_predict_instance_segmentation_forwards_parameters_and_conditioning(worl
     assert req.parameters == {"threshold": 0.75, "min_target_frac": 0.2}
     assert req.contour_ids == [c.id]
     assert req.model_registry_key == "sam2"
+    assert len(req.positive_exemplars) == 1
+
+
+def test_resolve_reference_images_progressive_search_exhaustion(world, monkeypatch):
+    """Progressive search continues past 1024 candidates until retrieval is exhausted or enough images are found."""
+    from app.services.exemplar_retrieval import ExemplarMatch
+
+    s = world["session"]
+    calls = []
+
+    # Mock retrieve_exemplars to simulate candidate 1200 being the first fully annotated image
+    img_far = world["far"]
+    c_far = _contour(s, world["far_mask"].id, label_id=world["label"].id)
+
+    def mock_retrieve_exemplars(session, strategy, query, model_id=None):
+        calls.append(query.top_k)
+        # For small top_k, return non-fully-annotated candidate images
+        # When top_k reaches 2048, include the far image which is fully annotated
+        if query.top_k < 2048:
+            # 128 incomplete images
+            return [
+                ExemplarMatch(contour_id=c_far.id, image_id=world["mid"].id, score=0.9 - i * 0.001)
+                for i in range(min(query.top_k, 1500))
+            ]
+        else:
+            matches = [
+                ExemplarMatch(contour_id=c_far.id, image_id=world["mid"].id, score=0.9 - i * 0.001)
+                for i in range(1200)
+            ]
+            matches.append(ExemplarMatch(contour_id=c_far.id, image_id=img_far.id, score=0.1))
+            return matches
+
+    monkeypatch.setattr(
+        "app.services.inference.conditioning_dispatcher.retrieve_exemplars",
+        mock_retrieve_exemplars,
+    )
+
+    exemplars, matches = resolve_reference_images(
+        s,
+        target_image_id=world["target"].id,
+        dataset_id=world["ds"].id,
+        strategy="global_scene",
+        concept_label_id=world["label"].id,
+        max_images=1,
+        requires_complete_annotation=True,
+        model_id=MODEL,
+    )
+    assert len(exemplars) == 1
+    assert exemplars[0].image_url == "/data/far.png"
+    # Verify search expanded past 1024
+    assert any(k > 1024 for k in calls)
+
+
+def test_predict_cross_image_forwards_source_aware_exemplars_and_positive_exemplars(world, monkeypatch):
+    """_predict_cross_image forwards exemplars, positive_exemplars, and contour_ids."""
+    from app.services.inference.execution import _predict_cross_image
+
+    captured_requests = []
+
+    class MockCrossImageService:
+        async def inference(self, request):
+            captured_requests.append(request)
+            return {"result": []}
+
+    monkeypatch.setattr(
+        "app.services.ai_services.cross_image.CrossImageService",
+        lambda: MockCrossImageService(),
+    )
+
+    s = world["session"]
+    c = _contour(s, world["near_mask"].id, label_id=world["label"].id)
+
+    step = ResolvedStep(
+        label_id=world["label"].id,
+        model_registry_key="cross_model",
+        task="cross-image-suggestion",
+        level=0,
+        label_name="coral",
+        model_name="CrossModel",
+        inputs={
+            "conditioning": {"count": 1, "strategy": "global_scene", "concept_text": None},
+            "parameters": {},
+        },
+        input_contract=InputContract(
+            task="cross-image-suggestion",
+            conditioning=ConditioningSpec(
+                kind="instances", unit="instance", min_units=1, max_units=5, user_selectable_count=True
+            ),
+            parameters=[],
+        ),
+    )
+    res = _predict_cross_image(s, step, world["target"], "u")
+    assert res == []
+    assert len(captured_requests) == 1
+    req = captured_requests[-1]
+    assert len(req.exemplars) == 1
+    assert req.exemplars[0].image_url == "/data/near.png"
+    assert req.exemplars[0].mask is not None
+    assert len(req.positive_exemplars) == 1
+    assert req.contour_ids == [c.id]

--- a/tests/test_conditioning_dispatcher.py
+++ b/tests/test_conditioning_dispatcher.py
@@ -1,0 +1,634 @@
+"""Tests for conditioning dispatcher and resolvers (Stage 4)."""
+import numpy as np
+import pytest
+from fastapi import HTTPException
+from sqlalchemy import create_engine, event
+from sqlalchemy.engine import Engine
+from sqlalchemy.orm import sessionmaker
+
+from app.database import database
+import app.database.datasets  # noqa: F401
+import app.database.images  # noqa: F401
+import app.database.masks  # noqa: F401
+import app.database.contours  # noqa: F401
+import app.database.labels  # noqa: F401
+import app.database.users  # noqa: F401
+import app.database.embeddings  # noqa: F401
+from app.database.contours import Contours
+from app.database.datasets import Datasets
+from app.database.embeddings import EMBEDDING_DIM, upsert_embedding
+from app.database.images import Images
+from app.database.labels import Labels
+from app.database.masks import Masks
+from app.database.users import Users
+from app.schemas.inference import ResolvedStep
+from app.services.inference.conditioning_dispatcher import (
+    dispatch_conditioning,
+    is_image_fully_annotated,
+    resolve_concept_text,
+    resolve_embedding_conditioning,
+    resolve_instance_conditioning,
+    resolve_reference_images,
+)
+from iquana_toolbox.schemas.input_contract import ConditioningSpec, InputContract
+from iquana_toolbox.schemas.training import HyperParameter
+from config import EMBEDDING_MODEL_ID
+
+MODEL = EMBEDDING_MODEL_ID
+
+
+@event.listens_for(Engine, "connect")
+def _fk_pragma(dbapi_connection, connection_record):
+    import sqlite3
+    if isinstance(dbapi_connection, sqlite3.Connection):
+        cur = dbapi_connection.cursor()
+        cur.execute("PRAGMA foreign_keys=ON")
+        cur.close()
+
+
+@pytest.fixture
+def session(tmp_path):
+    engine = create_engine(f"sqlite:///{tmp_path / 'test.db'}")
+    database.metadata.create_all(engine)
+    Session = sessionmaker(bind=engine)
+    s = Session()
+    try:
+        yield s
+    finally:
+        s.close()
+        engine.dispose()
+
+
+def _axis(*components):
+    v = np.zeros(EMBEDDING_DIM, dtype=np.float64)
+    for i, val in components:
+        v[i] = val
+    return v.tolist()
+
+
+def _image(session, dataset_id, name, fully_annotated=False):
+    img = Images(
+        dataset_id=dataset_id, file_name=f"{name}.png", file_path=f"/data/{name}.png",
+        thumbnail_file_path="/tmp/t.png", width=100, height=100, color_mode="RGB",
+        scale_x=1.0, scale_y=1.0, unit="px"
+    )
+    session.add(img)
+    session.flush()
+    mask = Masks(image_id=img.id, fully_annotated=fully_annotated, file_path=f"/tmp/{name}_m.png")
+    session.add(mask)
+    session.flush()
+    return img, mask
+
+
+def _contour(session, mask_id, label_id=None):
+    c = Contours(
+        mask_id=mask_id, added_by="u", confidence_score=1.0, label_id=label_id,
+        area=0.0, perimeter=0.0, circularity=0.0, diameter=0.0,
+        x=[0.1, 0.6, 0.6], y=[0.1, 0.1, 0.6]
+    )
+    session.add(c)
+    session.flush()
+    return c
+
+
+@pytest.fixture
+def world(session):
+    session.add(Users(username="u", hashed_password="x", is_admin=False))
+    session.flush()
+    ds = Datasets(name="A", description="", dataset_type="image", folder_path="/tmp/A", created_by="u")
+    session.add(ds)
+    session.flush()
+    label = Labels(dataset_id=ds.id, parent_id=None, name="coral", value=1)
+    session.add(label)
+    session.flush()
+
+    target, target_mask = _image(session, ds.id, "target", fully_annotated=False)
+    near, near_mask = _image(session, ds.id, "near", fully_annotated=True)
+    mid, mid_mask = _image(session, ds.id, "mid", fully_annotated=False)
+    far, far_mask = _image(session, ds.id, "far", fully_annotated=True)
+
+    upsert_embedding(session, image_id=target.id, kind="image_cls", model_id=MODEL, vector=_axis((0, 1.0)))
+    upsert_embedding(session, image_id=near.id, kind="image_cls", model_id=MODEL, vector=_axis((0, 1.0), (1, 0.1)))
+    upsert_embedding(session, image_id=mid.id, kind="image_cls", model_id=MODEL, vector=_axis((0, 1.0), (1, 0.2)))
+    upsert_embedding(session, image_id=far.id, kind="image_cls", model_id=MODEL, vector=_axis((1, 1.0)))
+
+    return dict(
+        session=session, ds=ds, label=label, target=target, target_mask=target_mask,
+        near=near, near_mask=near_mask, mid=mid, mid_mask=mid_mask, far=far, far_mask=far_mask
+    )
+
+
+def test_is_image_fully_annotated(world):
+    s = world["session"]
+    assert is_image_fully_annotated(s, world["near"].id) is True
+    assert is_image_fully_annotated(s, world["mid"].id) is False
+    assert is_image_fully_annotated(s, world["target"].id) is False
+
+
+def test_resolve_reference_images_enforces_completeness_and_max_units(world):
+    s = world["session"]
+    # Seed contours
+    c_near1 = _contour(s, world["near_mask"].id, label_id=world["label"].id)
+    c_near2 = _contour(s, world["near_mask"].id, label_id=world["label"].id)
+    c_mid = _contour(s, world["mid_mask"].id, label_id=world["label"].id)
+    c_far = _contour(s, world["far_mask"].id, label_id=world["label"].id)
+
+    # 1. With complete annotation required and max_images=1 (SAM 3 contract):
+    exemplars, matches = resolve_reference_images(
+        s,
+        target_image_id=world["target"].id,
+        dataset_id=world["ds"].id,
+        strategy="global_scene",
+        concept_label_id=world["label"].id,
+        max_images=1,
+        requires_complete_annotation=True,
+        model_id=MODEL,
+    )
+    # Only `near` image is selected (since mid is incomplete, and far is second choice)
+    assert len(exemplars) == 2  # c_near1 and c_near2
+    assert all(ex.image_url == "/data/near.png" for ex in exemplars)
+    assert len(matches) == 2
+    assert {m.contour_id for m in matches} == {c_near1.id, c_near2.id}
+
+    # 2. With complete annotation NOT required:
+    exemplars_any, matches_any = resolve_reference_images(
+        s,
+        target_image_id=world["target"].id,
+        dataset_id=world["ds"].id,
+        strategy="global_scene",
+        concept_label_id=world["label"].id,
+        max_images=2,
+        requires_complete_annotation=False,
+        model_id=MODEL,
+    )
+    # Both near and mid selected
+    urls = {ex.image_url for ex in exemplars_any}
+    assert urls == {"/data/near.png", "/data/mid.png"}
+
+
+def test_resolve_instances(world):
+    s = world["session"]
+    c1 = _contour(s, world["near_mask"].id, label_id=world["label"].id)
+    c2 = _contour(s, world["far_mask"].id, label_id=world["label"].id)
+
+    cids = resolve_instance_conditioning(
+        s,
+        dataset_id=world["ds"].id,
+        concept_label_id=world["label"].id,
+        max_instances=1,
+    )
+    assert len(cids) == 1
+    assert cids[0] in {c1.id, c2.id}
+
+
+def test_resolve_embeddings(world):
+    s = world["session"]
+    vec = resolve_embedding_conditioning(
+        s,
+        target_image_id=world["target"].id,
+        kind="image_cls",
+        model_id=MODEL,
+    )
+    assert vec is not None
+    assert len(vec) == EMBEDDING_DIM
+    assert vec[0] == 1.0
+
+
+def test_resolve_concept_text():
+    # Provided directly in inputs
+    assert resolve_concept_text(step_inputs={"conditioning": {"concept_text": "custom text"}}) == "custom text"
+    # Fallback to label
+    lbl = Labels(id=1, name="coral_label", value=1)
+    assert resolve_concept_text(step_inputs={}, label=lbl) == "coral_label"
+
+
+def test_dispatch_conditioning_all_kinds(world):
+    s = world["session"]
+    c_near = _contour(s, world["near_mask"].id, label_id=world["label"].id)
+
+    # 1. Kind: none
+    step_none = ResolvedStep(
+        label_id=world["label"].id,
+        model_registry_key="m2f",
+        task="instance-segmentation",
+        level=0,
+        label_name="coral",
+        model_name="Mask2Former",
+        inputs={"conditioning": {"count": 0, "strategy": None, "concept_text": None}, "parameters": {"threshold": 0.5}},
+        input_contract=InputContract(
+            task="instance-segmentation",
+            conditioning=ConditioningSpec(kind="none", user_selectable_count=False),
+            parameters=[HyperParameter(key="threshold", label="T", type="float", default_value=0.5)],
+        ),
+    )
+    res_none = dispatch_conditioning(s, step_none, world["target"])
+    assert res_none == {"kind": "none"}
+
+    # 2. Kind: concept_text
+    step_text = ResolvedStep(
+        label_id=world["label"].id,
+        model_registry_key="clipseg",
+        task="instance-segmentation",
+        level=0,
+        label_name="coral",
+        model_name="CLIPSeg",
+        inputs={"conditioning": {"count": 0, "strategy": None, "concept_text": "vibrant coral"}, "parameters": {}},
+        input_contract=InputContract(
+            task="instance-segmentation",
+            conditioning=ConditioningSpec(kind="concept_text", user_selectable_count=False),
+            parameters=[],
+        ),
+    )
+    res_text = dispatch_conditioning(s, step_text, world["target"])
+    assert res_text["kind"] == "concept_text"
+    assert res_text["concept_text"] == "vibrant coral"
+
+    # 3. Kind: reference_images
+    step_ref = ResolvedStep(
+        label_id=world["label"].id,
+        model_registry_key="sam3",
+        task="cross-image-suggestion",
+        level=0,
+        label_name="coral",
+        model_name="SAM 3",
+        inputs={"conditioning": {"count": 1, "strategy": "global_scene", "concept_text": None}, "parameters": {"threshold": 0.3}},
+        input_contract=InputContract(
+            task="cross-image-suggestion",
+            conditioning=ConditioningSpec(
+                kind="reference_images", unit="image", min_units=1, max_units=1,
+                requires_complete_annotation=True, user_selectable_count=False,
+            ),
+            parameters=[HyperParameter(key="threshold", label="T", type="float", default_value=0.3)],
+        ),
+    )
+    res_ref = dispatch_conditioning(s, step_ref, world["target"])
+    assert res_ref["kind"] == "reference_images"
+    assert len(res_ref["exemplars"]) == 1
+    assert res_ref["exemplars"][0].image_url == "/data/near.png"
+
+    # 4. Kind: instances
+    step_inst = ResolvedStep(
+        label_id=world["label"].id,
+        model_registry_key="sam2",
+        task="instance-segmentation",
+        level=0,
+        label_name="coral",
+        model_name="SAM 2",
+        inputs={"conditioning": {"count": 2, "strategy": None, "concept_text": None}, "parameters": {}},
+        input_contract=InputContract(
+            task="instance-segmentation",
+            conditioning=ConditioningSpec(kind="instances", unit="instance", min_units=1, max_units=5, user_selectable_count=True),
+            parameters=[],
+        ),
+    )
+    res_inst = dispatch_conditioning(s, step_inst, world["target"])
+    assert res_inst["kind"] == "instances"
+    assert len(res_inst["contour_ids"]) == 1
+    assert res_inst["contour_ids"][0] == c_near.id
+
+    # 5. Kind: embeddings
+    step_emb = ResolvedStep(
+        label_id=world["label"].id,
+        model_registry_key="embedder",
+        task="instance-segmentation",
+        level=0,
+        label_name="coral",
+        model_name="Embedder",
+        inputs={"conditioning": {"count": 0, "strategy": None, "concept_text": None}, "parameters": {}},
+        input_contract=InputContract(
+            task="instance-segmentation",
+            conditioning=ConditioningSpec(kind="embeddings", unit="vector", embedding_kinds=["image_cls"], user_selectable_count=False),
+            parameters=[],
+        ),
+    )
+    res_emb = dispatch_conditioning(s, step_emb, world["target"])
+    assert res_emb["kind"] == "embeddings"
+    assert res_emb["vector"] is not None
+
+
+def test_dispatch_conditioning_unsupported_kind_raises(world):
+    s = world["session"]
+    step_bad = ResolvedStep(
+        label_id=world["label"].id,
+        model_registry_key="m",
+        task="instance-segmentation",
+        level=0,
+        label_name="coral",
+        model_name="M",
+        inputs={"conditioning": {}, "parameters": {}},
+        input_contract=InputContract.model_construct(
+            task="instance-segmentation",
+            conditioning=ConditioningSpec.model_construct(kind="unsupported_kind", user_selectable_count=False),
+            parameters=[],
+        ),
+    )
+    with pytest.raises(ValueError, match="Unsupported conditioning kind 'unsupported_kind'"):
+        dispatch_conditioning(s, step_bad, world["target"])
+
+
+def test_dispatch_conditioning_multi_vector_embeddings(world):
+    s = world["session"]
+    # Seed image_cls on image, and region_mean on a contour on the target image (production schema behavior)
+    c = _contour(s, world["target_mask"].id, label_id=world["label"].id)
+    upsert_embedding(s, contour_id=c.id, kind="region_mean", model_id=MODEL, vector=_axis((1, 0.5)))
+
+    step_multi_emb = ResolvedStep(
+        label_id=world["label"].id,
+        model_registry_key="multi_embedder",
+        task="instance-segmentation",
+        level=0,
+        label_name="coral",
+        model_name="MultiEmbedder",
+        inputs={"conditioning": {"count": 0, "strategy": None, "concept_text": None}, "parameters": {}},
+        input_contract=InputContract(
+            task="instance-segmentation",
+            conditioning=ConditioningSpec(
+                kind="embeddings",
+                unit="vector",
+                embedding_kinds=["image_cls", "region_mean"],
+                user_selectable_count=False,
+            ),
+            parameters=[],
+        ),
+    )
+    res = dispatch_conditioning(s, step_multi_emb, world["target"])
+    assert res["kind"] == "embeddings"
+    assert "image_cls" in res["vectors"]
+    assert "region_mean" in res["vectors"]
+    assert len(res["vectors"]["image_cls"]) == EMBEDDING_DIM
+    assert len(res["vectors"]["region_mean"]) == EMBEDDING_DIM
+
+
+def test_dispatch_conditioning_region_mean_explicit_query_contour_id(world):
+    """Explicit query_contour_id selects precisely that contour's embedding vector."""
+    s = world["session"]
+    c1 = _contour(s, world["target_mask"].id, label_id=world["label"].id)
+    c2 = _contour(s, world["target_mask"].id, label_id=world["label"].id)
+    v1 = _axis((1, 0.2))
+    v2 = _axis((1, 0.8))
+    upsert_embedding(s, contour_id=c1.id, kind="region_mean", model_id=MODEL, vector=v1)
+    upsert_embedding(s, contour_id=c2.id, kind="region_mean", model_id=MODEL, vector=v2)
+
+    step = ResolvedStep(
+        label_id=world["label"].id,
+        model_registry_key="emb_model",
+        task="instance-segmentation",
+        level=0,
+        label_name="coral",
+        model_name="EmbModel",
+        inputs={"conditioning": {"count": 0, "strategy": None, "concept_text": None, "query_contour_id": c2.id}, "parameters": {}},
+        input_contract=InputContract(
+            task="instance-segmentation",
+            conditioning=ConditioningSpec(
+                kind="embeddings",
+                unit="vector",
+                embedding_kinds=["region_mean"],
+                user_selectable_count=False,
+            ),
+            parameters=[],
+        ),
+    )
+    res = dispatch_conditioning(s, step, world["target"])
+    assert res["vectors"]["region_mean"] == v2
+
+
+def test_dispatch_conditioning_query_contour_outside_dataset_rejected(world):
+    """A query_contour_id from another dataset is rejected and not resolved."""
+    s = world["session"]
+    other_ds = Datasets(name="B", description="", dataset_type="image", folder_path="/tmp/B", created_by="u")
+    s.add(other_ds)
+    s.flush()
+    other_img, other_mask = _image(s, dataset_id=other_ds.id, name="other")
+    c_foreign = _contour(s, other_mask.id, label_id=world["label"].id)
+    upsert_embedding(s, contour_id=c_foreign.id, kind="region_mean", model_id=MODEL, vector=_axis((1, 0.5)))
+
+    # Attempt to dispatch on world["target"] (which is dataset_id=1) using c_foreign.id
+    step = ResolvedStep(
+        label_id=world["label"].id,
+        model_registry_key="emb_model",
+        task="instance-segmentation",
+        level=0,
+        label_name="coral",
+        model_name="EmbModel",
+        inputs={"conditioning": {"count": 0, "strategy": None, "concept_text": None, "query_contour_id": c_foreign.id}, "parameters": {}},
+        input_contract=InputContract(
+            task="instance-segmentation",
+            conditioning=ConditioningSpec(
+                kind="embeddings",
+                unit="vector",
+                embedding_kinds=["region_mean"],
+                user_selectable_count=False,
+            ),
+            parameters=[],
+        ),
+    )
+    with pytest.raises(ValueError, match="missing required embedding.*region_mean"):
+        dispatch_conditioning(s, step, world["target"])
+
+
+
+def test_dispatch_conditioning_region_mean_deterministic_ordering_fallback(world):
+    """When query_contour_id is omitted, deterministic ordering selects the highest priority contour."""
+    s = world["session"]
+    c_older = _contour(s, world["target_mask"].id, label_id=world["label"].id)
+    c_newer = _contour(s, world["target_mask"].id, label_id=world["label"].id)
+    v_older = _axis((1, 0.1))
+    v_newer = _axis((1, 0.9))
+    upsert_embedding(s, contour_id=c_older.id, kind="region_mean", model_id=MODEL, vector=v_older)
+    upsert_embedding(s, contour_id=c_newer.id, kind="region_mean", model_id=MODEL, vector=v_newer)
+
+    step = ResolvedStep(
+        label_id=world["label"].id,
+        model_registry_key="emb_model",
+        task="instance-segmentation",
+        level=0,
+        label_name="coral",
+        model_name="EmbModel",
+        inputs={"conditioning": {"count": 0, "strategy": None, "concept_text": None}, "parameters": {}},
+        input_contract=InputContract(
+            task="instance-segmentation",
+            conditioning=ConditioningSpec(
+                kind="embeddings",
+                unit="vector",
+                embedding_kinds=["region_mean"],
+                user_selectable_count=False,
+            ),
+            parameters=[],
+        ),
+    )
+    res = dispatch_conditioning(s, step, world["target"])
+    # Deterministic order by id / created_at selects c_newer
+    assert res["vectors"]["region_mean"] == v_newer
+
+
+def test_dispatch_conditioning_missing_embedding_raises(world):
+    s = world["session"]
+    # Request a kind that is not present on target
+    step_missing_emb = ResolvedStep(
+        label_id=world["label"].id,
+        model_registry_key="custom_embedder",
+        task="instance-segmentation",
+        level=0,
+        label_name="coral",
+        model_name="CustomEmbedder",
+        inputs={"conditioning": {"count": 0, "strategy": None, "concept_text": None}, "parameters": {}},
+        input_contract=InputContract(
+            task="instance-segmentation",
+            conditioning=ConditioningSpec(
+                kind="embeddings",
+                unit="vector",
+                embedding_kinds=["non_existent_kind"],
+                user_selectable_count=False,
+            ),
+            parameters=[],
+        ),
+    )
+    with pytest.raises(ValueError, match="missing required embedding.*non_existent_kind"):
+        dispatch_conditioning(s, step_missing_emb, world["target"])
+
+
+def test_dispatch_conditioning_post_resolution_min_units_reference_images_raises(world):
+    s = world["session"]
+    # Seed 1 eligible contour on `near` (which is fully_annotated). `mid` is not fully annotated.
+    _contour(s, world["near_mask"].id, label_id=world["label"].id)
+
+    # Contract requires min_units=2 unique reference images, but only 1 eligible exists
+    step_ref_min2 = ResolvedStep(
+        label_id=world["label"].id,
+        model_registry_key="sam3",
+        task="cross-image-suggestion",
+        level=0,
+        label_name="coral",
+        model_name="SAM 3",
+        inputs={"conditioning": {"count": 2, "strategy": "global_scene", "concept_text": None}, "parameters": {"threshold": 0.3}},
+        input_contract=InputContract(
+            task="cross-image-suggestion",
+            conditioning=ConditioningSpec(
+                kind="reference_images", unit="image", min_units=2, max_units=5,
+                requires_complete_annotation=True, user_selectable_count=True,
+            ),
+            parameters=[HyperParameter(key="threshold", label="T", type="float", default_value=0.3)],
+        ),
+    )
+    with pytest.raises(ValueError, match="Resolved 1 unique reference image.*requires at least 2 min_units"):
+        dispatch_conditioning(s, step_ref_min2, world["target"])
+
+
+def test_dispatch_conditioning_post_resolution_min_units_instances_raises(world):
+    s = world["session"]
+    # Seed 1 contour
+    _contour(s, world["near_mask"].id, label_id=world["label"].id)
+
+    step_inst_min3 = ResolvedStep(
+        label_id=world["label"].id,
+        model_registry_key="sam2",
+        task="instance-segmentation",
+        level=0,
+        label_name="coral",
+        model_name="SAM 2",
+        inputs={"conditioning": {"count": 3, "strategy": None, "concept_text": None}, "parameters": {}},
+        input_contract=InputContract(
+            task="instance-segmentation",
+            conditioning=ConditioningSpec(kind="instances", unit="instance", min_units=3, max_units=5, user_selectable_count=True),
+            parameters=[],
+        ),
+    )
+    with pytest.raises(ValueError, match="Resolved 1 instance exemplar.*requires at least 3 min_units"):
+        dispatch_conditioning(s, step_inst_min3, world["target"])
+
+
+def test_predict_cross_image_with_concept_text_and_parameters(world, monkeypatch):
+    """Worker _predict_cross_image forwards concept_text, parameters, and conditioning to AI service."""
+    from app.services.inference.execution import _predict_cross_image
+
+    captured_requests = []
+
+    class MockCrossImageService:
+        async def inference(self, request):
+            captured_requests.append(request)
+            return {"result": []}
+
+    monkeypatch.setattr(
+        "app.services.ai_services.cross_image.CrossImageService",
+        lambda: MockCrossImageService(),
+    )
+
+    s = world["session"]
+
+    # 1. Concept text model on cross-image-suggestion with normalized parameters
+    step_text = ResolvedStep(
+        label_id=world["label"].id,
+        model_registry_key="text_seg",
+        task="cross-image-suggestion",
+        level=0,
+        label_name="coral",
+        model_name="TextSeg",
+        inputs={
+            "conditioning": {"count": 0, "strategy": None, "concept_text": "sea coral"},
+            "parameters": {"threshold": 0.45, "mask_threshold": 0.6},
+        },
+        input_contract=InputContract(
+            task="cross-image-suggestion",
+            conditioning=ConditioningSpec(kind="concept_text", user_selectable_count=False),
+            parameters=[
+                HyperParameter(key="threshold", label="T", type="float", default_value=0.3),
+                HyperParameter(key="mask_threshold", label="M", type="float", default_value=0.5),
+            ],
+        ),
+    )
+    res_text = _predict_cross_image(s, step_text, world["target"], "u")
+    assert res_text == []
+    assert len(captured_requests) == 1
+    req = captured_requests[-1]
+    assert req.exemplars == []
+    assert req.concept.name == "sea coral"
+    assert req.parameters == {"threshold": 0.45, "mask_threshold": 0.6}
+
+
+def test_predict_instance_segmentation_forwards_parameters_and_conditioning(world, monkeypatch):
+    """Worker _predict_instance_segmentation dispatches conditioning and forwards parameters/contour_ids/embeddings."""
+    from app.services.inference.execution import _predict_instance_segmentation
+
+    captured_requests = []
+
+    class MockInstanceSegmentationService:
+        async def inference(self, request):
+            captured_requests.append(request)
+            return {"result": []}
+
+    monkeypatch.setattr(
+        "app.services.ai_services.instance_segmentation.InstanceSegmentationService",
+        lambda: MockInstanceSegmentationService(),
+    )
+
+    s = world["session"]
+    c = _contour(s, world["near_mask"].id, label_id=world["label"].id)
+
+    # 1. Instance-segmentation with instance conditioning and hyperparameters
+    step_inst = ResolvedStep(
+        label_id=world["label"].id,
+        model_registry_key="sam2",
+        task="instance-segmentation",
+        level=0,
+        label_name="coral",
+        model_name="SAM 2",
+        inputs={
+            "conditioning": {"count": 1, "strategy": None, "concept_text": None},
+            "parameters": {"threshold": 0.75, "min_target_frac": 0.2},
+        },
+        input_contract=InputContract(
+            task="instance-segmentation",
+            conditioning=ConditioningSpec(kind="instances", unit="instance", min_units=1, max_units=5, user_selectable_count=True),
+            parameters=[
+                HyperParameter(key="threshold", label="T", type="float", default_value=0.5),
+                HyperParameter(key="min_target_frac", label="F", type="float", default_value=0.5),
+            ],
+        ),
+    )
+    res = _predict_instance_segmentation(s, step_inst, world["target"], "u")
+    assert res == []
+    assert len(captured_requests) == 1
+    req = captured_requests[-1]
+    assert req.parameters == {"threshold": 0.75, "min_target_frac": 0.2}
+    assert req.contour_ids == [c.id]
+    assert req.model_registry_key == "sam2"

--- a/tests/test_contract_resolver.py
+++ b/tests/test_contract_resolver.py
@@ -28,9 +28,49 @@ def test_resolve_input_contract_empty_contracts():
     contract, provenance = resolve_input_contract({"input_contracts": []}, "cross-image-suggestion")
     assert provenance == "legacy_default"
     assert contract == LEGACY_TASK_DEFAULTS["cross-image-suggestion"]
-    assert contract.conditioning.kind == "reference_images"
+    assert contract.conditioning.kind == "instances"
+    assert contract.conditioning.unit == "instance"
     assert contract.conditioning.min_units == 1
-    assert contract.conditioning.max_units == 1
+    assert contract.conditioning.max_units == 32
+    assert contract.conditioning.user_selectable_count is True
+    assert contract.parameters == []
+
+
+def test_resolve_input_contract_tag_overrides_artifact_contract():
+    """Registered model tag contracts override stale artifact-level contracts."""
+    stale_artifact_contract = {
+        "task": "instance-segmentation",
+        "conditioning": {"kind": "none", "user_selectable_count": False},
+        "parameters": [
+            {
+                "key": "threshold",
+                "label": "Stale Old Threshold",
+                "type": "float",
+                "default_value": 0.1,
+            }
+        ],
+    }
+    updated_tag_contract = {
+        "task": "instance-segmentation",
+        "conditioning": {"kind": "none", "user_selectable_count": False},
+        "parameters": [
+            {
+                "key": "threshold",
+                "label": "Updated Tag Threshold",
+                "type": "float",
+                "default_value": 0.85,
+            }
+        ],
+    }
+    model_info = {
+        "name": "model_with_stale_artifact",
+        "input_contracts": [stale_artifact_contract],
+        "tags": {"input_contracts": json.dumps([updated_tag_contract])},
+    }
+    contract, provenance = resolve_input_contract(model_info, "instance-segmentation")
+    assert provenance == "declared"
+    assert contract.parameters[0].label == "Updated Tag Threshold"
+    assert contract.parameters[0].default_value == 0.85
 
 
 def test_resolve_input_contract_declared_dict():

--- a/tests/test_contract_resolver.py
+++ b/tests/test_contract_resolver.py
@@ -1,0 +1,240 @@
+"""Unit tests for backend effective input contract resolver (Issue #27)."""
+from __future__ import annotations
+
+import json
+import pytest
+
+from iquana_toolbox.schemas.input_contract import ConditioningSpec, InputContract
+from iquana_toolbox.schemas.model_info import ModelInfo
+from iquana_toolbox.schemas.training import HyperParameter
+
+from app.services.inference.contract_resolver import (
+    LEGACY_TASK_DEFAULTS,
+    resolve_input_contract,
+)
+
+
+def test_resolve_input_contract_none_model_info():
+    """None model_info resolves to legacy default with 'legacy_default' provenance."""
+    contract, provenance = resolve_input_contract(None, "instance-segmentation")
+    assert provenance == "legacy_default"
+    assert contract == LEGACY_TASK_DEFAULTS["instance-segmentation"]
+    assert contract.task == "instance-segmentation"
+    assert contract.conditioning.kind == "none"
+
+
+def test_resolve_input_contract_empty_contracts():
+    """Empty input_contracts in dict resolves to legacy default."""
+    contract, provenance = resolve_input_contract({"input_contracts": []}, "cross-image-suggestion")
+    assert provenance == "legacy_default"
+    assert contract == LEGACY_TASK_DEFAULTS["cross-image-suggestion"]
+    assert contract.conditioning.kind == "reference_images"
+    assert contract.conditioning.min_units == 1
+    assert contract.conditioning.max_units == 1
+
+
+def test_resolve_input_contract_declared_dict():
+    """Dict model_info with declared contract resolves with 'declared' provenance."""
+    custom_contract = {
+        "task": "instance-segmentation",
+        "conditioning": {"kind": "none", "user_selectable_count": False},
+        "parameters": [
+            {
+                "key": "threshold",
+                "label": "Custom Threshold",
+                "type": "float",
+                "default_value": 0.65,
+                "min_value": 0.1,
+                "max_value": 0.9,
+            }
+        ],
+    }
+    model_info = {"name": "custom_m2f", "input_contracts": [custom_contract]}
+    contract, provenance = resolve_input_contract(model_info, "instance-segmentation")
+    assert provenance == "declared"
+    assert contract.task == "instance-segmentation"
+    assert len(contract.parameters) == 1
+    assert contract.parameters[0].default_value == 0.65
+
+
+def test_resolve_input_contract_declared_model_info_object():
+    """ModelInfo Pydantic object with input_contracts resolves with 'declared' provenance."""
+    custom_contract = InputContract(
+        task="instance-segmentation",
+        conditioning=ConditioningSpec(kind="none", user_selectable_count=False),
+        parameters=[
+            HyperParameter(
+                key="threshold",
+                label="Threshold",
+                type="float",
+                default_value=0.7,
+            )
+        ],
+    )
+    info = ModelInfo(
+        registry_key="custom-m2f",
+        name="Custom M2F",
+        description="desc",
+        usage_tip="tip",
+        status="ready",
+        input_contracts=[custom_contract],
+    )
+    contract, provenance = resolve_input_contract(info, "instance-segmentation")
+    assert provenance == "declared"
+    assert contract == custom_contract
+
+
+def test_resolve_input_contract_from_tags_json_dict():
+    """Tags dict carrying stringified input_contracts JSON parses and resolves correctly."""
+    custom_contract = {
+        "task": "cross-image-suggestion",
+        "conditioning": {
+            "kind": "reference_images",
+            "unit": "image",
+            "min_units": 1,
+            "max_units": 2,
+            "requires_complete_annotation": True,
+            "user_selectable_count": True,
+        },
+        "parameters": [],
+    }
+    model_info = {
+        "name": "sam3",
+        "tags": {"input_contracts": json.dumps([custom_contract])},
+    }
+    contract, provenance = resolve_input_contract(model_info, "cross-image-suggestion")
+    assert provenance == "declared"
+    assert contract.conditioning.max_units == 2
+
+
+def test_resolve_input_contract_from_tags_list():
+    """Tags list format carrying stringified input_contracts JSON parses and resolves correctly."""
+    custom_contract = {
+        "task": "instance-suggestion",
+        "conditioning": {
+            "kind": "instances",
+            "unit": "instance",
+            "min_units": 1,
+            "user_selectable_count": True,
+        },
+        "parameters": [],
+    }
+    model_info = {
+        "name": "sam3",
+        "tags": [{"key": "input_contracts", "value": json.dumps([custom_contract])}],
+    }
+    contract, provenance = resolve_input_contract(model_info, "instance-suggestion")
+    assert provenance == "declared"
+    assert contract.task == "instance-suggestion"
+
+
+def test_resolve_input_contract_declared_other_task_falls_back():
+    """Declared contracts that don't match requested task fall back to legacy default."""
+    model_info = {
+        "input_contracts": [
+            {
+                "task": "prompted-segmentation",
+                "conditioning": {"kind": "none", "user_selectable_count": False},
+                "parameters": [],
+            }
+        ]
+    }
+    contract, provenance = resolve_input_contract(model_info, "instance-segmentation")
+    assert provenance == "legacy_default"
+    assert contract == LEGACY_TASK_DEFAULTS["instance-segmentation"]
+
+
+def test_resolve_input_contract_duplicate_declared_tasks_raises():
+    """Duplicate task declarations in input_contracts must raise ValueError."""
+    model_info = {
+        "input_contracts": [
+            {
+                "task": "instance-segmentation",
+                "conditioning": {"kind": "none", "user_selectable_count": False},
+                "parameters": [],
+            },
+            {
+                "task": "instance-segmentation",
+                "conditioning": {"kind": "none", "user_selectable_count": False},
+                "parameters": [],
+            },
+        ]
+    }
+    with pytest.raises(ValueError, match="Duplicate declared input contract for task 'instance-segmentation'"):
+        resolve_input_contract(model_info, "instance-segmentation")
+
+
+def test_resolve_input_contract_malformed_declared_raises():
+    """Malformed declared contract must raise ValueError."""
+    model_info = {
+        "input_contracts": [
+            {
+                "task": "instance-segmentation",
+                "conditioning": {"kind": "none", "unit": "instance"},  # invalid: none cannot have unit
+            }
+        ]
+    }
+    with pytest.raises(ValueError, match="Malformed declared input contract"):
+        resolve_input_contract(model_info, "instance-segmentation")
+
+
+def test_resolve_input_contract_unknown_task_raises():
+    """Unknown task with no declared contract and no legacy default raises ValueError."""
+    with pytest.raises(ValueError, match="Unknown task 'unknown-specialist'"):
+        resolve_input_contract(None, "unknown-specialist")
+
+
+def test_resolve_input_contract_malformed_metadata_non_list_raises():
+    """Declaring non-list input_contracts in dict or stringified JSON must raise ValueError."""
+    with pytest.raises(ValueError, match="Malformed declared input_contracts: expected list"):
+        resolve_input_contract({"input_contracts": {"task": "instance-segmentation"}}, "instance-segmentation")
+
+    with pytest.raises(ValueError, match="Malformed declared input_contracts: expected list"):
+        resolve_input_contract({"input_contracts": 123}, "instance-segmentation")
+
+    with pytest.raises(ValueError, match="Malformed declared input_contracts: expected list"):
+        resolve_input_contract({"input_contracts": '{"task": "instance-segmentation"}'}, "instance-segmentation")
+
+    # Explicit null in dict or JSON string
+    with pytest.raises(ValueError, match="Malformed declared input_contracts: expected list, got None"):
+        resolve_input_contract({"input_contracts": None}, "instance-segmentation")
+
+    with pytest.raises(ValueError, match="Malformed declared input_contracts: expected list, got None"):
+        resolve_input_contract({"input_contracts": "null"}, "instance-segmentation")
+
+    # Tuple is rejected (list-only metadata)
+    with pytest.raises(ValueError, match="Malformed declared input_contracts: expected list, got tuple"):
+        resolve_input_contract({"input_contracts": ()}, "instance-segmentation")
+
+
+def test_resolve_input_contract_malformed_metadata_invalid_json_string_raises():
+    """Invalid JSON string in input_contracts must raise ValueError."""
+    with pytest.raises(ValueError, match="Malformed declared input_contracts JSON"):
+        resolve_input_contract({"input_contracts": "invalid-json"}, "instance-segmentation")
+
+
+def test_resolve_input_contract_malformed_tags_non_list_raises():
+    """Non-list tag value for input_contracts must raise ValueError."""
+    with pytest.raises(ValueError, match="Malformed declared input_contracts in tags"):
+        resolve_input_contract({"tags": {"input_contracts": 123}}, "instance-segmentation")
+
+    with pytest.raises(ValueError, match="Malformed declared input_contracts in tags: expected list, got None"):
+        resolve_input_contract({"tags": {"input_contracts": None}}, "instance-segmentation")
+
+    with pytest.raises(ValueError, match="Malformed declared input_contracts in tags: expected list, got None"):
+        resolve_input_contract({"tags": {"input_contracts": "null"}}, "instance-segmentation")
+
+    with pytest.raises(ValueError, match="Malformed declared input_contracts in tag value"):
+        resolve_input_contract({"tags": [{"key": "input_contracts", "value": 123}]}, "instance-segmentation")
+
+    with pytest.raises(ValueError, match="Malformed declared input_contracts in tag value: expected list, got None"):
+        resolve_input_contract({"tags": [{"key": "input_contracts", "value": None}]}, "instance-segmentation")
+
+    with pytest.raises(ValueError, match="Malformed declared input_contracts in tag value: expected list, got None"):
+        resolve_input_contract({"tags": [{"key": "input_contracts", "value": "null"}]}, "instance-segmentation")
+
+
+def test_resolve_input_contract_invalid_model_info_type_raises():
+    """Non-dict and non-ModelInfo model_info (other than None) must raise ValueError."""
+    with pytest.raises(ValueError, match="model_info must be a ModelInfo, dict, or None"):
+        resolve_input_contract("invalid-model-info-string", "instance-segmentation")

--- a/tests/test_inference_planning_normalization.py
+++ b/tests/test_inference_planning_normalization.py
@@ -1,0 +1,268 @@
+"""Tests for inference planning generic input normalization and contract snapshotting."""
+import pytest
+from fastapi import HTTPException
+from sqlalchemy import create_engine, event
+from sqlalchemy.engine import Engine
+from sqlalchemy.orm import sessionmaker
+
+from app.database import database
+import app.database.datasets  # noqa: F401
+import app.database.images  # noqa: F401
+import app.database.masks  # noqa: F401
+import app.database.contours  # noqa: F401
+import app.database.labels  # noqa: F401
+import app.database.users  # noqa: F401
+from app.database.datasets import Datasets
+from app.database.labels import Labels
+from app.database.users import Users
+from app.schemas.inference import InferenceStepRequest, ModelCatalog, ModelOption
+from app.services.inference.planning import resolve_steps
+from iquana_toolbox.schemas.input_contract import ConditioningSpec, InputContract
+from iquana_toolbox.schemas.training import HyperParameter
+
+
+@event.listens_for(Engine, "connect")
+def _fk_pragma(dbapi_connection, connection_record):
+    import sqlite3
+    if isinstance(dbapi_connection, sqlite3.Connection):
+        cur = dbapi_connection.cursor()
+        cur.execute("PRAGMA foreign_keys=ON")
+        cur.close()
+
+
+@pytest.fixture
+def session(tmp_path):
+    engine = create_engine(f"sqlite:///{tmp_path / 'test.db'}")
+    database.metadata.create_all(engine)
+    Session = sessionmaker(bind=engine)
+    s = Session()
+    try:
+        yield s
+    finally:
+        s.close()
+        engine.dispose()
+
+
+@pytest.fixture
+def dataset(session):
+    session.add(Users(username="u", hashed_password="x", is_admin=False))
+    session.flush()
+    ds = Datasets(name="A", description="", dataset_type="image", folder_path="/tmp/A", created_by="u")
+    session.add(ds)
+    session.flush()
+    lbl_cell = Labels(dataset_id=ds.id, parent_id=None, name="cell", value=1)
+    session.add(lbl_cell)
+    session.flush()
+    lbl_nucleus = Labels(dataset_id=ds.id, parent_id=lbl_cell.id, name="nucleus", value=2)
+    session.add(lbl_nucleus)
+    session.flush()
+    return dict(session=session, ds=ds, cell=lbl_cell, nucleus=lbl_nucleus)
+
+
+def _mock_catalog(monkeypatch, options: list[ModelOption]):
+    catalog = ModelCatalog(models=options, default_model_per_task={})
+    monkeypatch.setattr(
+        "app.services.inference.planning.model_catalog",
+        lambda db, ds_id: catalog,
+    )
+
+
+def test_resolve_steps_with_canonical_inputs(dataset, monkeypatch):
+    s = dataset["session"]
+    contract = InputContract(
+        task="instance-segmentation",
+        conditioning=ConditioningSpec(kind="none", user_selectable_count=False),
+        parameters=[
+            HyperParameter(key="threshold", label="T", type="float", default_value=0.5, min_value=0.0, max_value=1.0)
+        ],
+    )
+    option = ModelOption(
+        registry_key="m2f",
+        task="instance-segmentation",
+        name="Mask2Former",
+        version="1",
+        label_ids=[dataset["cell"].id],
+        is_default=True,
+        input_contract=contract,
+        provenance="declared",
+    )
+    _mock_catalog(monkeypatch, [option])
+
+    # Valid canonical request
+    req = InferenceStepRequest(
+        label_id=dataset["cell"].id,
+        model_registry_key="m2f",
+        task="instance-segmentation",
+        inputs={"parameters": {"threshold": 0.75}},
+    )
+    resolved = resolve_steps(s, dataset["ds"].id, [req])
+    assert len(resolved) == 1
+    step = resolved[0]
+    assert step.inputs["parameters"]["threshold"] == 0.75
+    assert step.input_contract.task == "instance-segmentation"
+    assert step.provenance == "declared"
+
+
+def test_canonical_inputs_ignore_stale_legacy_fields():
+    req = InferenceStepRequest(
+        label_id=1,
+        model_registry_key="m2f",
+        task="instance-segmentation",
+        inputs={"parameters": {"threshold": 0.75}},
+        min_confidence=50.0,
+        retrieval_strategy="obsolete",
+        top_k=100,
+    )
+
+    assert req.inputs["parameters"]["threshold"] == 0.75
+    assert req.min_confidence == 0.0
+    assert req.retrieval_strategy is None
+    assert req.top_k == 5
+
+
+def test_resolve_steps_with_legacy_fields_synthesizes_inputs(dataset, monkeypatch):
+    s = dataset["session"]
+    contract = InputContract(
+        task="cross-image-suggestion",
+        conditioning=ConditioningSpec(
+            kind="reference_images", unit="image", min_units=1, max_units=1,
+            requires_complete_annotation=True, user_selectable_count=False,
+        ),
+        parameters=[
+            HyperParameter(key="threshold", label="T", type="float", default_value=0.3, min_value=0.0, max_value=1.0),
+            HyperParameter(key="mask_threshold", label="M", type="float", default_value=0.5),
+            HyperParameter(key="min_target_frac", label="F", type="float", default_value=0.5),
+        ],
+    )
+    option = ModelOption(
+        registry_key="sam3",
+        task="cross-image-suggestion",
+        name="SAM 3",
+        version="1",
+        label_ids=[],
+        is_default=True,
+        input_contract=contract,
+        provenance="declared",
+    )
+    _mock_catalog(monkeypatch, [option])
+
+    # Legacy request without `inputs`
+    req = InferenceStepRequest(
+        label_id=dataset["cell"].id,
+        model_registry_key="sam3",
+        task="cross-image-suggestion",
+        retrieval_strategy="global_scene",
+        top_k=1,
+        min_confidence=0.4,
+    )
+    resolved = resolve_steps(s, dataset["ds"].id, [req])
+    assert len(resolved) == 1
+    step = resolved[0]
+    assert step.inputs["parameters"]["threshold"] == 0.4
+    assert step.inputs["parameters"]["mask_threshold"] == 0.5
+    assert step.inputs["parameters"]["min_target_frac"] == 0.5
+    assert step.inputs["conditioning"]["strategy"] == "global_scene"
+    assert step.inputs["conditioning"]["count"] == 1
+
+
+def test_resolve_steps_invalid_inputs_raises_400(dataset, monkeypatch):
+    s = dataset["session"]
+    contract = InputContract(
+        task="instance-segmentation",
+        conditioning=ConditioningSpec(kind="none", user_selectable_count=False),
+        parameters=[
+            HyperParameter(key="threshold", label="T", type="float", default_value=0.5, min_value=0.0, max_value=1.0)
+        ],
+    )
+    option = ModelOption(
+        registry_key="m2f",
+        task="instance-segmentation",
+        name="Mask2Former",
+        version="1",
+        label_ids=[],
+        is_default=True,
+        input_contract=contract,
+        provenance="declared",
+    )
+    _mock_catalog(monkeypatch, [option])
+
+    # Out of range threshold (1.5 > max_value 1.0)
+    req = InferenceStepRequest(
+        label_id=dataset["cell"].id,
+        model_registry_key="m2f",
+        task="instance-segmentation",
+        inputs={"parameters": {"threshold": 1.5}},
+    )
+    with pytest.raises(HTTPException) as exc:
+        resolve_steps(s, dataset["ds"].id, [req])
+    assert exc.value.status_code == 400
+    assert "greater than max_value" in exc.value.detail
+
+
+def test_resolve_steps_legacy_top_k_default_sam3(dataset, monkeypatch):
+    """Legacy cross-image request with default top_k=5 maps safely to SAM 3 single-image contract."""
+    s = dataset["session"]
+    contract = InputContract(
+        task="cross-image-suggestion",
+        conditioning=ConditioningSpec(
+            kind="reference_images", unit="image", min_units=1, max_units=1,
+            requires_complete_annotation=True, user_selectable_count=False,
+        ),
+        parameters=[
+            HyperParameter(key="threshold", label="T", type="float", default_value=0.3, min_value=0.0, max_value=1.0),
+            HyperParameter(key="mask_threshold", label="M", type="float", default_value=0.5),
+            HyperParameter(key="min_target_frac", label="F", type="float", default_value=0.5),
+        ],
+    )
+    option = ModelOption(
+        registry_key="sam3",
+        task="cross-image-suggestion",
+        name="SAM 3",
+        version="1",
+        label_ids=[],
+        is_default=True,
+        input_contract=contract,
+        provenance="declared",
+    )
+    _mock_catalog(monkeypatch, [option])
+
+    # Default top_k=5 should not raise ValueError when user_selectable_count is False / max_units=1
+    req = InferenceStepRequest(
+        label_id=dataset["cell"].id,
+        model_registry_key="sam3",
+        task="cross-image-suggestion",
+        retrieval_strategy="global_scene",
+        top_k=5,
+        min_confidence=0.3,
+    )
+    resolved = resolve_steps(s, dataset["ds"].id, [req])
+    assert len(resolved) == 1
+    step = resolved[0]
+    assert step.inputs["conditioning"]["count"] == 1
+    assert step.inputs["parameters"]["threshold"] == 0.3
+
+
+def test_resolved_step_migrates_persisted_legacy_plan_step():
+    """Deserializing persisted plan steps lacking contract snapshots resolves correct task defaults."""
+    from app.schemas.inference import ResolvedStep
+
+    legacy_persisted_cross_image_step = {
+        "label_id": 1,
+        "model_registry_key": "sam3",
+        "task": "cross-image-suggestion",
+        "retrieval_strategy": "global_scene",
+        "top_k": 5,
+        "min_confidence": 0.3,
+        "level": 0,
+        "label_name": "cell",
+        "model_name": "SAM 3",
+    }
+
+    step = ResolvedStep.model_validate(legacy_persisted_cross_image_step)
+    assert step.task == "cross-image-suggestion"
+    assert step.input_contract.task == "cross-image-suggestion"
+    assert step.input_contract.conditioning.kind == "reference_images"
+    assert step.inputs["conditioning"]["strategy"] == "global_scene"
+    assert step.inputs["conditioning"]["count"] == 1
+    assert step.inputs["parameters"]["threshold"] == 0.3
+    assert step.provenance == "legacy_default"

--- a/tests/test_inference_planning_normalization.py
+++ b/tests/test_inference_planning_normalization.py
@@ -103,21 +103,32 @@ def test_resolve_steps_with_canonical_inputs(dataset, monkeypatch):
     assert step.provenance == "declared"
 
 
-def test_canonical_inputs_ignore_stale_legacy_fields():
+def test_canonical_inputs_keep_postfilter_and_ignore_mirrored_retrieval_fields():
     req = InferenceStepRequest(
         label_id=1,
         model_registry_key="m2f",
         task="instance-segmentation",
         inputs={"parameters": {"threshold": 0.75}},
-        min_confidence=50.0,
+        min_confidence=0.6,
         retrieval_strategy="obsolete",
         top_k=100,
     )
 
     assert req.inputs["parameters"]["threshold"] == 0.75
-    assert req.min_confidence == 0.0
+    assert req.min_confidence == 0.6
     assert req.retrieval_strategy is None
     assert req.top_k == 5
+
+
+def test_canonical_inputs_validate_postfilter_confidence():
+    with pytest.raises(ValueError, match="less than or equal to 1"):
+        InferenceStepRequest(
+            label_id=1,
+            model_registry_key="legacy-model",
+            task="instance-segmentation",
+            inputs={"parameters": {}},
+            min_confidence=50.0,
+        )
 
 
 def test_resolve_steps_with_legacy_fields_synthesizes_inputs(dataset, monkeypatch):

--- a/tests/test_inference_planning_normalization.py
+++ b/tests/test_inference_planning_normalization.py
@@ -103,21 +103,17 @@ def test_resolve_steps_with_canonical_inputs(dataset, monkeypatch):
     assert step.provenance == "declared"
 
 
-def test_canonical_inputs_keep_postfilter_and_ignore_mirrored_retrieval_fields():
+def test_canonical_inputs_keep_postfilter_confidence():
     req = InferenceStepRequest(
         label_id=1,
         model_registry_key="m2f",
         task="instance-segmentation",
         inputs={"parameters": {"threshold": 0.75}},
         min_confidence=0.6,
-        retrieval_strategy="obsolete",
-        top_k=100,
     )
 
     assert req.inputs["parameters"]["threshold"] == 0.75
     assert req.min_confidence == 0.6
-    assert req.retrieval_strategy is None
-    assert req.top_k == 5
 
 
 def test_canonical_inputs_validate_postfilter_confidence():
@@ -131,7 +127,7 @@ def test_canonical_inputs_validate_postfilter_confidence():
         )
 
 
-def test_resolve_steps_with_legacy_fields_synthesizes_inputs(dataset, monkeypatch):
+def test_resolve_steps_with_empty_inputs_synthesizes_contract_defaults(dataset, monkeypatch):
     s = dataset["session"]
     contract = InputContract(
         task="cross-image-suggestion",
@@ -157,23 +153,21 @@ def test_resolve_steps_with_legacy_fields_synthesizes_inputs(dataset, monkeypatc
     )
     _mock_catalog(monkeypatch, [option])
 
-    # Legacy request without `inputs`
+    # Request without explicit `inputs`
     req = InferenceStepRequest(
         label_id=dataset["cell"].id,
         model_registry_key="sam3",
         task="cross-image-suggestion",
-        retrieval_strategy="global_scene",
-        top_k=1,
         min_confidence=0.4,
     )
     resolved = resolve_steps(s, dataset["ds"].id, [req])
     assert len(resolved) == 1
     step = resolved[0]
-    assert step.inputs["parameters"]["threshold"] == 0.4
+    assert step.inputs["parameters"]["threshold"] == 0.3
     assert step.inputs["parameters"]["mask_threshold"] == 0.5
     assert step.inputs["parameters"]["min_target_frac"] == 0.5
-    assert step.inputs["conditioning"]["strategy"] == "global_scene"
     assert step.inputs["conditioning"]["count"] == 1
+    assert step.min_confidence == 0.4
 
 
 def test_resolve_steps_invalid_inputs_raises_400(dataset, monkeypatch):
@@ -208,49 +202,6 @@ def test_resolve_steps_invalid_inputs_raises_400(dataset, monkeypatch):
         resolve_steps(s, dataset["ds"].id, [req])
     assert exc.value.status_code == 400
     assert "greater than max_value" in exc.value.detail
-
-
-def test_resolve_steps_legacy_top_k_default_sam3(dataset, monkeypatch):
-    """Legacy cross-image request with default top_k=5 maps safely to SAM 3 single-image contract."""
-    s = dataset["session"]
-    contract = InputContract(
-        task="cross-image-suggestion",
-        conditioning=ConditioningSpec(
-            kind="reference_images", unit="image", min_units=1, max_units=1,
-            requires_complete_annotation=True, user_selectable_count=False,
-        ),
-        parameters=[
-            HyperParameter(key="threshold", label="T", type="float", default_value=0.3, min_value=0.0, max_value=1.0),
-            HyperParameter(key="mask_threshold", label="M", type="float", default_value=0.5),
-            HyperParameter(key="min_target_frac", label="F", type="float", default_value=0.5),
-        ],
-    )
-    option = ModelOption(
-        registry_key="sam3",
-        task="cross-image-suggestion",
-        name="SAM 3",
-        version="1",
-        label_ids=[],
-        is_default=True,
-        input_contract=contract,
-        provenance="declared",
-    )
-    _mock_catalog(monkeypatch, [option])
-
-    # Default top_k=5 should not raise ValueError when user_selectable_count is False / max_units=1
-    req = InferenceStepRequest(
-        label_id=dataset["cell"].id,
-        model_registry_key="sam3",
-        task="cross-image-suggestion",
-        retrieval_strategy="global_scene",
-        top_k=5,
-        min_confidence=0.3,
-    )
-    resolved = resolve_steps(s, dataset["ds"].id, [req])
-    assert len(resolved) == 1
-    step = resolved[0]
-    assert step.inputs["conditioning"]["count"] == 1
-    assert step.inputs["parameters"]["threshold"] == 0.3
 
 
 def test_resolved_step_migrates_persisted_legacy_plan_step():

--- a/tests/test_inference_planning_normalization.py
+++ b/tests/test_inference_planning_normalization.py
@@ -261,8 +261,8 @@ def test_resolved_step_migrates_persisted_legacy_plan_step():
     step = ResolvedStep.model_validate(legacy_persisted_cross_image_step)
     assert step.task == "cross-image-suggestion"
     assert step.input_contract.task == "cross-image-suggestion"
-    assert step.input_contract.conditioning.kind == "reference_images"
+    assert step.input_contract.conditioning.kind == "instances"
     assert step.inputs["conditioning"]["strategy"] == "global_scene"
-    assert step.inputs["conditioning"]["count"] == 1
-    assert step.inputs["parameters"]["threshold"] == 0.3
+    assert step.inputs["conditioning"]["count"] == 5
+    assert step.inputs["parameters"] == {}
     assert step.provenance == "legacy_default"

--- a/tests/test_input_validator.py
+++ b/tests/test_input_validator.py
@@ -200,13 +200,13 @@ def test_validate_and_normalize_inputs_query_contour_id():
             {"conditioning": {"strategy": "global_scene", "query_contour_id": 42}},
         )
 
-    # 3. Rejected on instances conditioning
+    # 3. Rejected on instances conditioning without retrieval strategy
     contract_inst = InputContract(
         task="instance-segmentation",
         conditioning=ConditioningSpec(kind="instances", unit="instance", min_units=1, max_units=5),
         parameters=[],
     )
-    with pytest.raises(ValueError, match="Conditioning kind 'instances' does not accept query_contour_id"):
+    with pytest.raises(ValueError, match="Conditioning kind 'instances' without a retrieval strategy does not accept query_contour_id"):
         validate_and_normalize_inputs(contract_inst, {"conditioning": {"query_contour_id": 42}})
 
     # 4. Accepted on embeddings with region_mean
@@ -244,3 +244,20 @@ def test_validate_and_normalize_inputs_query_contour_id():
     )
     with pytest.raises(ValueError, match="does not accept query_contour_id"):
         validate_and_normalize_inputs(contract_none, {"conditioning": {"query_contour_id": 42}})
+
+
+def test_validate_and_normalize_inputs_strategy_registration_check():
+    """Unregistered retrieval strategies are rejected; known ones are accepted."""
+    contract = InputContract(
+        task="cross-image-suggestion",
+        conditioning=ConditioningSpec(kind="reference_images", unit="image", min_units=1, max_units=1),
+        parameters=[],
+    )
+
+    # 1. Unregistered strategy fails
+    with pytest.raises(ValueError, match="Unknown retrieval strategy 'not_registered'"):
+        validate_and_normalize_inputs(contract, {"conditioning": {"strategy": "not_registered"}})
+
+    # 2. Known strategy succeeds
+    res = validate_and_normalize_inputs(contract, {"conditioning": {"strategy": "concept_annotations"}})
+    assert res["conditioning"]["strategy"] == "concept_annotations"

--- a/tests/test_input_validator.py
+++ b/tests/test_input_validator.py
@@ -1,0 +1,246 @@
+"""Unit tests for backend generic inference input validator (Issue #27)."""
+from __future__ import annotations
+
+import pytest
+
+from iquana_toolbox.schemas.input_contract import ConditioningSpec, InputContract
+from iquana_toolbox.schemas.training import HyperParameter
+
+from app.services.inference.input_validator import validate_and_normalize_inputs
+
+
+def test_validate_and_normalize_inputs_fills_defaults():
+    """Omitted parameters receive declared defaults."""
+    contract = InputContract(
+        task="instance-segmentation",
+        conditioning=ConditioningSpec(kind="none", user_selectable_count=False),
+        parameters=[
+            HyperParameter(
+                key="threshold",
+                label="Threshold",
+                type="float",
+                default_value=0.5,
+                min_value=0.0,
+                max_value=1.0,
+            ),
+            HyperParameter(
+                key="mode",
+                label="Mode",
+                type="str",
+                default_value="standard",
+                options=["fast", "standard", "accurate"],
+            ),
+        ],
+    )
+    res = validate_and_normalize_inputs(contract, None)
+    assert res == {
+        "conditioning": {"count": 0, "strategy": None, "concept_text": None, "query_contour_id": None},
+        "parameters": {"threshold": 0.5, "mode": "standard"},
+    }
+
+
+def test_validate_and_normalize_inputs_rejects_unknown_top_level_key():
+    """Unknown keys in top-level inputs envelope are rejected."""
+    contract = InputContract(
+        task="instance-segmentation",
+        conditioning=ConditioningSpec(kind="none", user_selectable_count=False),
+        parameters=[],
+    )
+    with pytest.raises(ValueError, match="Unknown keys in inputs envelope"):
+        validate_and_normalize_inputs(contract, {"bogus": 123})
+
+
+def test_validate_and_normalize_inputs_rejects_unknown_param():
+    """Unknown parameter keys are rejected."""
+    contract = InputContract(
+        task="instance-segmentation",
+        conditioning=ConditioningSpec(kind="none", user_selectable_count=False),
+        parameters=[HyperParameter(key="threshold", label="Threshold", type="float", default_value=0.5)],
+    )
+    with pytest.raises(ValueError, match="Unknown parameter.*invalid_param"):
+        validate_and_normalize_inputs(contract, {"parameters": {"invalid_param": 0.5}})
+
+
+def test_validate_and_normalize_inputs_type_validation():
+    """Parameter types are validated strictly and float integers coerced."""
+    contract = InputContract(
+        task="dummy",
+        conditioning=ConditioningSpec(kind="none", user_selectable_count=False),
+        parameters=[
+            HyperParameter(key="flag", label="Flag", type="bool", default_value=True),
+            HyperParameter(key="count", label="Count", type="int", default_value=5),
+            HyperParameter(key="rate", label="Rate", type="float", default_value=1),
+            HyperParameter(key="name", label="Name", type="str", default_value="test"),
+        ],
+    )
+    # Int default coerced to float
+    res = validate_and_normalize_inputs(contract, {})
+    assert res["parameters"]["rate"] == 1.0
+    assert isinstance(res["parameters"]["rate"], float)
+
+    # Bool type check
+    with pytest.raises(ValueError, match="must be a bool"):
+        validate_and_normalize_inputs(contract, {"parameters": {"flag": "true"}})
+    with pytest.raises(ValueError, match="must be a bool"):
+        validate_and_normalize_inputs(contract, {"parameters": {"flag": 1}})
+
+    # Int type check
+    with pytest.raises(ValueError, match="must be an int"):
+        validate_and_normalize_inputs(contract, {"parameters": {"count": True}})
+    with pytest.raises(ValueError, match="must be an int"):
+        validate_and_normalize_inputs(contract, {"parameters": {"count": 2.5}})
+
+    # Float type check
+    with pytest.raises(ValueError, match="must be a finite float"):
+        validate_and_normalize_inputs(contract, {"parameters": {"rate": "1.0"}})
+    with pytest.raises(ValueError, match="must be a finite float"):
+        validate_and_normalize_inputs(contract, {"parameters": {"rate": float("nan")}})
+
+    # Str type check
+    with pytest.raises(ValueError, match="must be a str"):
+        validate_and_normalize_inputs(contract, {"parameters": {"name": 123}})
+
+
+def test_validate_and_normalize_inputs_bounds_and_options():
+    """Min/max bounds and allowed options are strictly enforced."""
+    contract = InputContract(
+        task="dummy",
+        conditioning=ConditioningSpec(kind="none", user_selectable_count=False),
+        parameters=[
+            HyperParameter(key="threshold", label="Threshold", type="float", default_value=0.5, min_value=0.1, max_value=0.9),
+            HyperParameter(key="mode", label="Mode", type="str", default_value="a", options=["a", "b"]),
+        ],
+    )
+    with pytest.raises(ValueError, match="less than min_value"):
+        validate_and_normalize_inputs(contract, {"parameters": {"threshold": 0.05}})
+    with pytest.raises(ValueError, match="greater than max_value"):
+        validate_and_normalize_inputs(contract, {"parameters": {"threshold": 0.95}})
+    with pytest.raises(ValueError, match="not in allowed options"):
+        validate_and_normalize_inputs(contract, {"parameters": {"mode": "c"}})
+
+
+def test_validate_and_normalize_inputs_conditioning_none_rejects_irrelevant_keys():
+    """Conditioning kind 'none' rejects strategy, concept_text, and count > 0."""
+    contract = InputContract(
+        task="instance-segmentation",
+        conditioning=ConditioningSpec(kind="none", user_selectable_count=False),
+        parameters=[],
+    )
+    with pytest.raises(ValueError, match="does not accept a retrieval strategy"):
+        validate_and_normalize_inputs(contract, {"conditioning": {"strategy": "global_scene"}})
+    with pytest.raises(ValueError, match="does not accept concept_text"):
+        validate_and_normalize_inputs(contract, {"conditioning": {"concept_text": "cell"}})
+    with pytest.raises(ValueError, match="does not accept count > 0"):
+        validate_and_normalize_inputs(contract, {"conditioning": {"count": 5}})
+
+
+def test_validate_and_normalize_inputs_conditioning_concept_text():
+    """Conditioning kind 'concept_text' accepts concept_text and rejects strategy."""
+    contract = InputContract(
+        task="text-seg",
+        conditioning=ConditioningSpec(kind="concept_text", user_selectable_count=False),
+        parameters=[],
+    )
+    res = validate_and_normalize_inputs(contract, {"conditioning": {"concept_text": "cell"}})
+    assert res["conditioning"]["concept_text"] == "cell"
+    assert res["conditioning"]["count"] == 0
+    assert res["conditioning"]["strategy"] is None
+
+    with pytest.raises(ValueError, match="does not accept a retrieval strategy"):
+        validate_and_normalize_inputs(contract, {"conditioning": {"strategy": "global_scene"}})
+
+
+def test_validate_and_normalize_inputs_conditioning_cardinality_bounds():
+    """Cardinality count bounds are enforced for counted conditioning."""
+    contract = InputContract(
+        task="cross-image-suggestion",
+        conditioning=ConditioningSpec(
+            kind="reference_images",
+            unit="image",
+            min_units=1,
+            max_units=1,
+            requires_complete_annotation=True,
+            user_selectable_count=False,
+        ),
+        parameters=[],
+    )
+    # Default count filled to 1
+    res = validate_and_normalize_inputs(contract, {"conditioning": {"strategy": "global_scene"}})
+    assert res["conditioning"]["count"] == 1
+    assert res["conditioning"]["strategy"] == "global_scene"
+
+    # Below min
+    with pytest.raises(ValueError, match="below min_units"):
+        validate_and_normalize_inputs(contract, {"conditioning": {"count": 0, "strategy": "global_scene"}})
+
+    # Above max
+    with pytest.raises(ValueError, match="exceeds max_units"):
+        validate_and_normalize_inputs(contract, {"conditioning": {"count": 2, "strategy": "global_scene"}})
+
+
+def test_validate_and_normalize_inputs_query_contour_id():
+    """query_contour_id is normalized as integer and rejected where irrelevant."""
+    # 1. Accepted on reference_images with region-based strategy
+    contract_ref = InputContract(
+        task="cross-image-suggestion",
+        conditioning=ConditioningSpec(kind="reference_images", unit="image", min_units=1, max_units=5),
+        parameters=[],
+    )
+    res = validate_and_normalize_inputs(
+        contract_ref,
+        {"conditioning": {"strategy": "concept_region", "query_contour_id": 42}},
+    )
+    assert res["conditioning"]["query_contour_id"] == 42
+    assert res["conditioning"]["strategy"] == "concept_region"
+
+    # 2. Rejected on reference_images with global_scene strategy
+    with pytest.raises(ValueError, match="does not accept query_contour_id"):
+        validate_and_normalize_inputs(
+            contract_ref,
+            {"conditioning": {"strategy": "global_scene", "query_contour_id": 42}},
+        )
+
+    # 3. Rejected on instances conditioning
+    contract_inst = InputContract(
+        task="instance-segmentation",
+        conditioning=ConditioningSpec(kind="instances", unit="instance", min_units=1, max_units=5),
+        parameters=[],
+    )
+    with pytest.raises(ValueError, match="Conditioning kind 'instances' does not accept query_contour_id"):
+        validate_and_normalize_inputs(contract_inst, {"conditioning": {"query_contour_id": 42}})
+
+    # 4. Accepted on embeddings with region_mean
+    contract_emb_region = InputContract(
+        task="instance-segmentation",
+        conditioning=ConditioningSpec(
+            kind="embeddings", unit="vector", embedding_kinds=["image_cls", "region_mean"], user_selectable_count=False
+        ),
+        parameters=[],
+    )
+    res_emb = validate_and_normalize_inputs(contract_emb_region, {"conditioning": {"query_contour_id": 99}})
+    assert res_emb["conditioning"]["query_contour_id"] == 99
+
+    # 5. Rejected on embeddings with only image_cls
+    contract_emb_image = InputContract(
+        task="instance-segmentation",
+        conditioning=ConditioningSpec(kind="embeddings", unit="vector", embedding_kinds=["image_cls"], user_selectable_count=False),
+        parameters=[],
+    )
+    with pytest.raises(ValueError, match="Embedding conditioning without 'region_mean' does not accept query_contour_id"):
+        validate_and_normalize_inputs(contract_emb_image, {"conditioning": {"query_contour_id": 99}})
+
+    # 6. Non-integer validation
+    with pytest.raises(ValueError, match="query_contour_id must be an integer"):
+        validate_and_normalize_inputs(
+            contract_ref,
+            {"conditioning": {"strategy": "concept_region", "query_contour_id": "invalid"}},
+        )
+
+    # 7. Rejected on 'none' kind
+    contract_none = InputContract(
+        task="instance-segmentation",
+        conditioning=ConditioningSpec(kind="none", user_selectable_count=False),
+        parameters=[],
+    )
+    with pytest.raises(ValueError, match="does not accept query_contour_id"):
+        validate_and_normalize_inputs(contract_none, {"conditioning": {"query_contour_id": 42}})

--- a/tests/test_model_catalog.py
+++ b/tests/test_model_catalog.py
@@ -1,0 +1,144 @@
+"""Unit tests for backend model catalog with effective contracts (Issue #27)."""
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from app.database import database
+import app.database.datasets  # noqa: F401
+import app.database.labels  # noqa: F401
+import app.database.users  # noqa: F401
+from app.database.datasets import Datasets
+from app.database.labels import Labels
+from app.database.users import Users
+from app.schemas.inference import ModelCatalog
+from app.services.inference import planning
+from iquana_toolbox.schemas.input_contract import ConditioningSpec, InputContract
+from iquana_toolbox.schemas.training import HyperParameter
+
+
+@pytest.fixture
+def db_session(tmp_path):
+    engine = create_engine(f"sqlite:///{tmp_path / 'catalog_test.db'}")
+    database.metadata.create_all(engine)
+    db = sessionmaker(bind=engine)()
+
+    user = Users(username="tester", hashed_password="pw")
+    db.add(user)
+    dataset = Datasets(name="test_ds", description="", dataset_type="image",
+                       folder_path=str(tmp_path), created_by="tester")
+    db.add(dataset)
+    db.flush()
+
+    label1 = Labels(dataset_id=dataset.id, name="cell", value=1)
+    label2 = Labels(dataset_id=dataset.id, name="nucleus", value=2)
+    db.add_all([label1, label2])
+    db.commit()
+
+    return dict(db=db, dataset=dataset, label1=label1, label2=label2)
+
+
+def test_model_catalog_attaches_contracts_and_provenance(monkeypatch, db_session):
+    """Catalog resolves declared contracts and legacy fallback contracts with provenance."""
+    db = db_session["db"]
+    dataset_id = db_session["dataset"].id
+
+    # Model 1: Declared contract for instance-segmentation
+    m1_contract = InputContract(
+        task="instance-segmentation",
+        conditioning=ConditioningSpec(kind="none", user_selectable_count=False),
+        parameters=[HyperParameter(key="threshold", label="T", type="float", default_value=0.7)],
+    )
+    m1_info = {
+        "registry_key": "custom-m2f",
+        "name": "Custom M2F",
+        "input_contracts": [m1_contract.model_dump()],
+        "label_ids": [db_session["label1"].id],
+    }
+
+    # Model 2: Legacy model with no input_contracts
+    m2_info = {
+        "registry_key": "legacy-m2f",
+        "name": "Legacy M2F",
+        "label_ids": [],
+    }
+
+    def fake_list_available_models(task: str):
+        if task == "instance-segmentation":
+            return {"result": [m1_info, m2_info]}
+        return {"result": []}
+
+    monkeypatch.setattr(planning, "list_available_models", fake_list_available_models)
+    monkeypatch.setattr(planning, "strategy_options", lambda db, ds_id: [])
+
+    catalog: ModelCatalog = planning.model_catalog(db, dataset_id)
+
+    assert len(catalog.models) == 2
+    # Custom M2F was trained on label1 in this dataset, so it sorts first
+    assert catalog.models[0].registry_key == "custom-m2f"
+    assert catalog.models[0].trained_on_dataset is True
+    assert catalog.models[0].provenance == "declared"
+    assert catalog.models[0].input_contract.parameters[0].default_value == 0.7
+
+    # Legacy M2F resolves legacy_default
+    assert catalog.models[1].registry_key == "legacy-m2f"
+    assert catalog.models[1].trained_on_dataset is False
+    assert catalog.models[1].provenance == "legacy_default"
+    assert catalog.models[1].input_contract.task == "instance-segmentation"
+
+
+def test_model_catalog_includes_concept_text_and_none_cross_image_without_embeddings(monkeypatch, db_session):
+    """Cross-image models with none/concept_text conditioning are offered even when no retrieval strategy is usable."""
+    db = db_session["db"]
+    dataset_id = db_session["dataset"].id
+
+    # Model with reference_images conditioning (needs embeddings/retrieval)
+    ref_contract = InputContract(
+        task="cross-image-suggestion",
+        conditioning=ConditioningSpec(
+            kind="reference_images",
+            unit="image",
+            min_units=1,
+            max_units=1,
+            requires_complete_annotation=True,
+            user_selectable_count=False,
+        ),
+        parameters=[],
+    )
+    m_ref = {
+        "registry_key": "sam3-ref",
+        "name": "SAM3 Reference",
+        "input_contracts": [ref_contract.model_dump()],
+    }
+
+    # Model with concept_text conditioning (does not need embeddings)
+    text_contract = InputContract(
+        task="cross-image-suggestion",
+        conditioning=ConditioningSpec(kind="concept_text", user_selectable_count=False),
+        parameters=[],
+    )
+    m_text = {
+        "registry_key": "text-model",
+        "name": "Text Concept Model",
+        "input_contracts": [text_contract.model_dump()],
+    }
+
+    def fake_list_available_models(task: str):
+        if task == "cross-image-suggestion":
+            return {"result": [m_ref, m_text]}
+        return {"result": []}
+
+    monkeypatch.setattr(planning, "list_available_models", fake_list_available_models)
+    # No available retrieval strategies (cross_image_usable = False)
+    strat_opt = MagicMock()
+    strat_opt.model_dump.return_value = {"name": "global_scene", "available": False}
+    monkeypatch.setattr(planning, "strategy_options", lambda db, ds_id: [strat_opt])
+
+    catalog: ModelCatalog = planning.model_catalog(db, dataset_id)
+
+    # Only m_text should be included; m_ref is excluded because embeddings are unavailable
+    assert len(catalog.models) == 1
+    assert catalog.models[0].registry_key == "text-model"
+    assert catalog.models[0].input_contract.conditioning.kind == "concept_text"

--- a/tests/test_model_registry.py
+++ b/tests/test_model_registry.py
@@ -2,7 +2,10 @@ from contextlib import contextmanager
 import json
 from types import SimpleNamespace
 
+import pytest
+
 from app.services import model_registry
+from app.services.inference.contract_resolver import resolve_input_contract
 
 
 def test_full_model_info_returns_trained_model_metadata_name(monkeypatch):
@@ -18,6 +21,7 @@ def test_full_model_info_returns_trained_model_metadata_name(monkeypatch):
         )
 
     monkeypatch.setattr(model_registry.mlflow.models, "get_model_info", get_model_info)
+    monkeypatch.setattr(model_registry.MODEL_REGISTRY.client, "get_registered_model", lambda _key: None)
 
     result = model_registry._full_model_info("trained-model")
 
@@ -66,6 +70,7 @@ def test_full_model_info_resolves_legacy_training_ids_to_names(monkeypatch):
 
     monkeypatch.setattr(model_registry.mlflow.models, "get_model_info", get_model_info)
     monkeypatch.setattr(model_registry, "get_context_session", fake_context_session)
+    monkeypatch.setattr(model_registry.MODEL_REGISTRY.client, "get_registered_model", lambda _key: None)
 
     result = model_registry._full_model_info("legacy-model")
 
@@ -79,8 +84,42 @@ def test_full_model_info_falls_back_when_metadata_lookup_fails(monkeypatch):
         raise RuntimeError("model version is unavailable")
 
     monkeypatch.setattr(model_registry.mlflow.models, "get_model_info", get_model_info)
+    monkeypatch.setattr(model_registry.MODEL_REGISTRY.client, "get_registered_model", lambda _key: None)
 
     assert model_registry._full_model_info("missing-model") == {
         "registry_key": "missing-model",
         "name": "missing-model",
     }
+
+
+def test_full_model_info_does_not_fall_back_to_stale_contract_on_malformed_registry_tag(monkeypatch):
+    stale_artifact_contract = [{"task": "instance-segmentation", "conditioning": {"kind": "none"}}]
+
+    def get_model_info(_uri):
+        return SimpleNamespace(
+            metadata={
+                "registry_key": "broken-model",
+                "name": "Broken Model",
+                "input_contracts": stale_artifact_contract,
+            }
+        )
+
+    registered_model = SimpleNamespace(
+        name="broken-model",
+        description=None,
+        tags={"input_contracts": "not-json"},
+    )
+
+    monkeypatch.setattr(model_registry.mlflow.models, "get_model_info", get_model_info)
+    monkeypatch.setattr(
+        model_registry.MODEL_REGISTRY.client,
+        "get_registered_model",
+        lambda _key: registered_model,
+    )
+
+    result = model_registry._full_model_info("broken-model")
+
+    assert "input_contracts" not in result
+    assert result["tags"]["input_contracts"] == "not-json"
+    with pytest.raises(ValueError, match="Malformed input_contracts tag JSON"):
+        resolve_input_contract(result, "instance-segmentation")

--- a/uv.lock
+++ b/uv.lock
@@ -705,7 +705,7 @@ requires-dist = [
     { name = "fastapi", extras = ["standard"], specifier = ">=0.68.0" },
     { name = "httpx", specifier = ">=0.24.0" },
     { name = "instructor", specifier = ">=1.3.0" },
-    { name = "iquana-toolbox", git = "https://github.com/Iquana-tool/iquana-toolbox.git" },
+    { name = "iquana-toolbox", git = "https://github.com/shivamtawari/iquana-toolbox.git?rev=ffe891d7a2e9260400654d777f34e44ba4b745bf" },
     { name = "litellm", specifier = ">=1.40.0" },
     { name = "numpy", specifier = ">=1.21.0" },
     { name = "opencv-python", specifier = ">=4.11.0.86" },
@@ -1546,7 +1546,7 @@ wheels = [
 [[package]]
 name = "iquana-toolbox"
 version = "0.1.0"
-source = { git = "https://github.com/Iquana-tool/iquana-toolbox.git#b5fbd064342d31b34cea079d0e0900fc431057c2" }
+source = { git = "https://github.com/shivamtawari/iquana-toolbox.git?rev=ffe891d7a2e9260400654d777f34e44ba4b745bf#ffe891d7a2e9260400654d777f34e44ba4b745bf" }
 dependencies = [
     { name = "cachetools" },
     { name = "mlflow" },

--- a/uv.lock
+++ b/uv.lock
@@ -705,7 +705,7 @@ requires-dist = [
     { name = "fastapi", extras = ["standard"], specifier = ">=0.68.0" },
     { name = "httpx", specifier = ">=0.24.0" },
     { name = "instructor", specifier = ">=1.3.0" },
-    { name = "iquana-toolbox", git = "https://github.com/shivamtawari/iquana-toolbox.git?rev=ffe891d7a2e9260400654d777f34e44ba4b745bf" },
+    { name = "iquana-toolbox", git = "https://github.com/Iquana-tool/iquana-toolbox.git?rev=425a08aaed1f23a7f98aa0680eb7ae2d7af40a21" },
     { name = "litellm", specifier = ">=1.40.0" },
     { name = "numpy", specifier = ">=1.21.0" },
     { name = "opencv-python", specifier = ">=4.11.0.86" },
@@ -1546,7 +1546,7 @@ wheels = [
 [[package]]
 name = "iquana-toolbox"
 version = "0.1.0"
-source = { git = "https://github.com/shivamtawari/iquana-toolbox.git?rev=ffe891d7a2e9260400654d777f34e44ba4b745bf#ffe891d7a2e9260400654d777f34e44ba4b745bf" }
+source = { git = "https://github.com/Iquana-tool/iquana-toolbox.git?rev=425a08aaed1f23a7f98aa0680eb7ae2d7af40a21#425a08aaed1f23a7f98aa0680eb7ae2d7af40a21" }
 dependencies = [
     { name = "cachetools" },
     { name = "mlflow" },


### PR DESCRIPTION
- Related to [Issue #27](https://github.com/Iquana-tool/iquana-tool/issues/27).
- Connects model input contracts to inference planning and execution.
- Forwards complete reference annotations and embedding exemplars.
- Uses the canonical request fields.
- Prevents model parameters such as threshold from changing the global confidence filter.